### PR TITLE
フォームをReact Hook Form API対応に移行し、認証をServer Actionsに更新 #37

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,8 @@
       "Bash(cp:*)",
       "Bash(gh pr view:*)",
       "Bash(git stash:*)",
-      "Bash(docker-compose exec:*)"
+      "Bash(docker-compose exec:*)",
+      "WebFetch(domain:react-hook-form.com)"
     ],
     "deny": []
   },

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.1.1",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.2.3",
@@ -20,8 +21,9 @@
         "react": "^19.0.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
-        "react-hook-form": "^7.56.4",
-        "tailwind-merge": "^3.3.1"
+        "react-hook-form": "^7.60.0",
+        "tailwind-merge": "^3.3.1",
+        "zod": "^4.0.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -247,6 +249,17 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1135,7 +1148,6 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
       "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
-      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
       },
@@ -1229,7 +1241,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
@@ -1340,6 +1351,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -5639,7 +5656,6 @@
       "version": "7.60.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
       "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
@@ -6834,6 +6850,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
+      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/next/package.json
+++ b/next/package.json
@@ -10,6 +10,7 @@
     "format": "next lint --fix --dir src"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
@@ -22,8 +23,9 @@
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.56.4",
-    "tailwind-merge": "^3.3.1"
+    "react-hook-form": "^7.60.0",
+    "tailwind-merge": "^3.3.1",
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/next/src/app/actions/auth-actions.ts
+++ b/next/src/app/actions/auth-actions.ts
@@ -1,0 +1,150 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+const API_BASE_URL = process.env.INTERNAL_API_URL || 'http://rails:3000/api/v1';
+
+// サインイン
+export async function signInAction(formData: FormData) {
+  try {
+    const email = formData.get('email') as string;
+    const password = formData.get('password') as string;
+
+    if (!email || !password) {
+      return { success: false, error: 'メールアドレスとパスワードを入力してください' };
+    }
+
+    const response = await fetch(`${API_BASE_URL}/auth/sign_in`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email, password }),
+    });
+
+    if (response.ok) {
+      // レスポンスヘッダーから認証トークンを取得
+      const accessToken = response.headers.get('access-token');
+      const client = response.headers.get('client');
+      const uid = response.headers.get('uid');
+
+      if (accessToken && client && uid) {
+        // クッキーに認証情報を保存
+        const cookieStore = await cookies();
+        const cookieOptions = {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: process.env.NODE_ENV === 'production' ? 'none' as const : 'lax' as const,
+          path: '/',
+        };
+
+        cookieStore.set('access_token', accessToken, cookieOptions);
+        cookieStore.set('client', client, cookieOptions);
+        cookieStore.set('uid', uid, cookieOptions);
+      }
+
+      return { success: true };
+    } else {
+      const errorData = await response.json();
+      return {
+        success: false,
+        error: errorData.errors?.[0] || 'ログインに失敗しました',
+      };
+    }
+  } catch (error) {
+    console.error('Sign in error:', error);
+    return {
+      success: false,
+      error: 'ログインに失敗しました',
+    };
+  }
+}
+
+// サインアップ
+export async function signUpAction(formData: FormData) {
+  try {
+    const email = formData.get('email') as string;
+    const password = formData.get('password') as string;
+    const passwordConfirmation = formData.get('passwordConfirmation') as string;
+
+    if (!email || !password || !passwordConfirmation) {
+      return { success: false, error: '必要な情報を入力してください' };
+    }
+
+    if (password !== passwordConfirmation) {
+      return { success: false, error: 'パスワードが一致しません' };
+    }
+
+    const response = await fetch(`${API_BASE_URL}/auth`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email,
+        password,
+        password_confirmation: passwordConfirmation,
+        confirm_success_url: process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:8000/',
+      }),
+    });
+
+    if (response.ok) {
+      return {
+        success: true,
+        message: '登録が完了しました。メールを確認してください。',
+      };
+    } else {
+      const errorData = await response.json();
+      return {
+        success: false,
+        error: errorData.errors?.full_messages?.[0] || '登録に失敗しました',
+      };
+    }
+  } catch (error) {
+    console.error('Sign up error:', error);
+    return {
+      success: false,
+      error: '登録に失敗しました',
+    };
+  }
+}
+
+// サインアウト
+export async function signOutAction() {
+  try {
+    const cookieStore = await cookies();
+    
+    // 認証情報を取得
+    const accessToken = cookieStore.get('access_token')?.value;
+    const client = cookieStore.get('client')?.value;
+    const uid = cookieStore.get('uid')?.value;
+
+    // Rails APIにサインアウトリクエストを送信
+    if (accessToken && client && uid) {
+      await fetch(`${API_BASE_URL}/auth/sign_out`, {
+        method: 'DELETE',
+        headers: {
+          'access-token': accessToken,
+          'client': client,
+          'uid': uid,
+        },
+      });
+    }
+
+    // Next.js側でもクッキーをクリア（開発環境での確実な削除のため）
+    cookieStore.delete('access_token');
+    cookieStore.delete('client');
+    cookieStore.delete('uid');
+  } catch (error) {
+    console.error('Sign out error:', error);
+    // エラーが発生してもクッキーはクリアする
+    const cookieStore = await cookies();
+    cookieStore.delete('access_token');
+    cookieStore.delete('client');
+    cookieStore.delete('uid');
+  }
+
+  // サインインページへリダイレクト
+  redirect('/sign_in');
+}

--- a/next/src/app/components/ClientRunningCalendar.tsx
+++ b/next/src/app/components/ClientRunningCalendar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 
 interface RunRecord {
@@ -21,6 +21,12 @@ export default function ClientRunningCalendar({
   currentDate: initialDate,
 }: ClientRunningCalendarProps) {
   const [currentDate, setCurrentDate] = useState(initialDate || new Date());
+  const [today, setToday] = useState<Date | null>(null);
+
+  // クライアントサイドでのみ今日の日付を設定
+  useEffect(() => {
+    setToday(new Date());
+  }, []);
 
   // 現在の年月
   const year = currentDate.getFullYear();
@@ -184,7 +190,7 @@ export default function ClientRunningCalendar({
       <div className="grid grid-cols-7 gap-1">
         {calendarDays.map((date, index) => {
           const isCurrentMonth = date.getMonth() === month;
-          const isToday = date.toDateString() === new Date().toDateString();
+          const isToday = today && date.toDateString() === today.toDateString();
           const hasRun = hasRecord(date);
           const record = getRecordForDate(date);
           const isWeekend = date.getDay() === 0 || date.getDay() === 6;
@@ -193,22 +199,14 @@ export default function ClientRunningCalendar({
             <div
               key={index}
               onClick={() => isCurrentMonth && handleDateClick(date)}
-              className={`
-                relative h-12 flex items-center justify-center text-sm transition-all duration-200 rounded-lg
-                ${
-                  !isCurrentMonth
-                    ? "text-gray-300"
-                    : "cursor-pointer hover:bg-gray-100"
-                }
-                ${isToday ? "ring-2 ring-blue-400 bg-blue-50" : ""}
-                ${
-                  hasRun && isCurrentMonth
-                    ? "bg-gradient-to-br from-emerald-400 to-emerald-500 text-white font-bold shadow-md hover:shadow-lg"
-                    : ""
-                }
-                ${isWeekend && !hasRun && isCurrentMonth ? "text-gray-500" : ""}
-                ${!isCurrentMonth ? "cursor-default" : ""}
-              `}
+              className={[
+                "relative h-12 flex items-center justify-center text-sm transition-all duration-200 rounded-lg",
+                !isCurrentMonth ? "text-gray-300" : "cursor-pointer hover:bg-gray-100",
+                isToday === true ? "ring-2 ring-blue-400 bg-blue-50" : "",
+                hasRun && isCurrentMonth ? "bg-gradient-to-br from-emerald-400 to-emerald-500 text-white font-bold shadow-md hover:shadow-lg" : "",
+                isWeekend && !hasRun && isCurrentMonth ? "text-gray-500" : "",
+                !isCurrentMonth ? "cursor-default" : ""
+              ].filter(Boolean).join(" ")}
             >
               <span className="z-10 relative">{date.getDate()}</span>
 
@@ -224,9 +222,10 @@ export default function ClientRunningCalendar({
               )}
 
               {/* 今日のマーカー */}
-              {isToday && !hasRun && (
-                <div className="absolute inset-0 bg-blue-400 opacity-20 rounded-lg"></div>
-              )}
+              <div 
+                className="absolute inset-0 bg-blue-400 opacity-20 rounded-lg"
+                style={{ display: isToday && !hasRun ? 'block' : 'none' }}
+              />
             </div>
           );
         })}

--- a/next/src/app/components/ClientYearlyGoalForm.tsx
+++ b/next/src/app/components/ClientYearlyGoalForm.tsx
@@ -1,51 +1,73 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { setYearlyGoal } from '../actions/running-actions';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage, FormDescription } from '@/components/ui/form';
+import { updateYearlyGoal } from '../actions/running-actions';
+
+const yearlyGoalSchema = z.object({
+  distance_goal: z.union([
+    z.number().min(50, '年間目標距離は50km以上で入力してください'),
+    z.literal('').transform(() => 0)
+  ]),
+});
+
+type YearlyGoalFormData = {
+  distance_goal: number | '';
+};
 
 interface ClientYearlyGoalFormProps {
   currentGoal: number;
-  isOpen?: boolean;
-  onClose?: () => void;
+  isOpen: boolean;
+  onClose: () => void;
   showWelcomeMessage?: boolean;
 }
 
-export default function ClientYearlyGoalForm({ currentGoal, isOpen = false, onClose, showWelcomeMessage = false }: ClientYearlyGoalFormProps) {
-  const [modalOpen, setModalOpen] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+export default function ClientYearlyGoalForm({ currentGoal, isOpen, onClose, showWelcomeMessage = false }: ClientYearlyGoalFormProps) {
 
-  // 外部から制御される場合
-  const isExternallyControlled = isOpen !== undefined && onClose !== undefined;
-  const currentModalOpen = isExternallyControlled ? isOpen : modalOpen;
+  const form = useForm<YearlyGoalFormData>({
+    resolver: zodResolver(yearlyGoalSchema),
+    defaultValues: {
+      distance_goal: '',
+    },
+  });
 
-  const handleSubmit = async (formData: FormData) => {
-    setIsSubmitting(true);
-    try {
-      await setYearlyGoal(formData);
-      handleClose();
-    } catch (error) {
-      console.error('Failed to set yearly goal:', error);
-      alert('年間目標の設定に失敗しました');
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
 
-  const handleClose = () => {
-    if (isExternallyControlled && onClose) {
+  const handleClose = useCallback(() => {
+    form.reset();
+    setError(null);
+    if (onClose) {
       onClose();
-    } else {
-      setModalOpen(false);
     }
+  }, [form, onClose]);
+
+  const onSubmit = async (data: YearlyGoalFormData) => {
+    setError(null);
+    const formData = new FormData();
+    const distance = data.distance_goal === '' ? 0 : data.distance_goal;
+    formData.append('distance_goal', distance.toString());
+    
+    startTransition(async () => {
+      const result = await updateYearlyGoal(formData);
+      if (result.success) {
+        form.reset();
+        handleClose();
+      } else {
+        setError(result.error || '年間目標の設定に失敗しました');
+      }
+    });
   };
 
 
   return (
-    <Dialog open={currentModalOpen} onOpenChange={handleClose}>
+    <Dialog open={isOpen} onOpenChange={handleClose}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle className="text-xl font-bold text-gray-800">
@@ -59,44 +81,65 @@ export default function ClientYearlyGoalForm({ currentGoal, isOpen = false, onCl
             </p>
           )}
           
-          <form action={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="distance_goal">年間目標距離 (km)</Label>
-              <Input
-                type="number"
-                id="distance_goal"
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
                 name="distance_goal"
-                step="0.1"
-                min="50"
-                max="2000"
-                required
-                defaultValue={currentGoal}
-                placeholder="500.0"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>年間目標距離 (km)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.1"
+                        min="50"
+                        max="2000"
+                        placeholder="500.0"
+                        {...field}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          if (value === '') {
+                            field.onChange('');
+                          } else {
+                            const numValue = parseFloat(value);
+                            field.onChange(isNaN(numValue) ? '' : numValue);
+                          }
+                        }}
+                        value={field.value || ''}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      現在の目標: {currentGoal}km (推奨: 300-1000km)
+                    </FormDescription>
+                    <FormMessage />
+                    {error && (
+                      <p className="text-sm text-red-500">{error}</p>
+                    )}
+                  </FormItem>
+                )}
               />
-              <p className="text-xs text-muted-foreground">
-                現在の目標: {currentGoal}km (推奨: 300-1000km)
-              </p>
-            </div>
             
             <div className="flex gap-3 pt-4">
               <Button
                 type="submit"
-                disabled={isSubmitting}
+                disabled={isPending || form.formState.isSubmitting}
                 className="flex-1 bg-emerald-500 hover:bg-emerald-600"
               >
-                {isSubmitting ? '保存中...' : (showWelcomeMessage ? '年間目標を設定' : '目標を変更')}
+                {isPending || form.formState.isSubmitting ? '保存中...' : (showWelcomeMessage ? '年間目標を設定' : '目標を変更')}
               </Button>
               <Button
                 type="button"
                 variant="outline"
                 onClick={handleClose}
-                disabled={isSubmitting}
+                disabled={isPending || form.formState.isSubmitting}
                 className="flex-1"
               >
                 {showWelcomeMessage ? '後で設定' : 'キャンセル'}
               </Button>
             </div>
-          </form>
+            </form>
+          </Form>
         </DialogContent>
       </Dialog>
   );

--- a/next/src/app/components/LogoutButton.tsx
+++ b/next/src/app/components/LogoutButton.tsx
@@ -1,28 +1,23 @@
 "use client";
-import { useState } from "react";
-import { signOut } from "@/lib/client-auth";
+import { useTransition } from "react";
+import { signOutAction } from "@/app/actions/auth-actions";
 
 export default function LogoutButton() {
-  const [loading, setLoading] = useState(false);
+  const [isPending, startTransition] = useTransition();
 
-  const handleLogout = async () => {
-    setLoading(true);
-    try {
-      await signOut();
-    } catch (error) {
-      console.error("ログアウトエラー:", error);
-    } finally {
-      setLoading(false);
-    }
+  const handleLogout = () => {
+    startTransition(async () => {
+      await signOutAction();
+    });
   };
 
   return (
     <button
       onClick={handleLogout}
-      disabled={loading}
+      disabled={isPending}
       className="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded transition disabled:opacity-50"
     >
-      {loading ? "ログアウト中..." : "ログアウト"}
+      {isPending ? "ログアウト中..." : "ログアウト"}
     </button>
   );
 }

--- a/next/src/app/sign_up/SignUpForm.tsx
+++ b/next/src/app/sign_up/SignUpForm.tsx
@@ -1,99 +1,143 @@
 "use client";
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { signUp } from "@/lib/client-auth";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { signUpAction } from "@/app/actions/auth-actions";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const signUpSchema = z.object({
+  email: z.string().email("有効なメールアドレスを入力してください"),
+  password: z.string().min(6, "パスワードは6文字以上で入力してください"),
+  passwordConfirmation: z.string().min(1, "確認パスワードを入力してください"),
+}).refine((data) => data.password === data.passwordConfirmation, {
+  message: "パスワードが一致しません",
+  path: ["passwordConfirmation"],
+});
+
+type SignUpFormData = z.infer<typeof signUpSchema>;
 
 export default function SignUpForm() {
   const router = useRouter();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [passwordConfirmation, setPasswordConfirmation] = useState("");
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
-  const [loading, setLoading] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  
+  const form = useForm<SignUpFormData>({
+    resolver: zodResolver(signUpSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+      passwordConfirmation: '',
+    },
+  });
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setLoading(true);
+  const onSubmit = async (data: SignUpFormData) => {
     setError("");
     setSuccess("");
 
-    if (password !== passwordConfirmation) {
-      setError("パスワードが一致しません");
-      setLoading(false);
-      return;
-    }
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.append('email', data.email);
+      formData.append('password', data.password);
+      formData.append('passwordConfirmation', data.passwordConfirmation);
+      
+      const result = await signUpAction(formData);
 
-    const result = await signUp(email, password, passwordConfirmation);
-
-    if (result.success) {
-      setSuccess(
-        result.message || "登録が完了しました。メールを確認してください。"
-      );
-      setTimeout(() => router.push("/sign_in"), 2000);
-    } else {
-      setError(result.error || "登録に失敗しました");
-    }
-    setLoading(false);
+      if (result.success) {
+        setSuccess(
+          result.message || "登録が完了しました。メールを確認してください。"
+        );
+        setTimeout(() => router.push("/sign_in"), 2000);
+      } else {
+        setError(result.error || "登録に失敗しました");
+      }
+    });
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-5">
-      <div>
-        <label className="block text-gray-700 font-semibold mb-1">
-          メールアドレス
-        </label>
-        <input
-          type="email"
-          className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-400"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-          disabled={loading}
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-gray-700 font-semibold">
+                メールアドレス
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type="email"
+                  className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-400"
+                  disabled={isPending || form.formState.isSubmitting}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
         />
-      </div>
-      <div>
-        <label className="block text-gray-700 font-semibold mb-1">
-          パスワード
-        </label>
-        <input
-          type="password"
-          className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-400"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-          disabled={loading}
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-gray-700 font-semibold">
+                パスワード
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-400"
+                  disabled={isPending || form.formState.isSubmitting}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
         />
-      </div>
-      <div>
-        <label className="block text-gray-700 font-semibold mb-1">
-          パスワード（確認）
-        </label>
-        <input
-          type="password"
-          className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-400"
-          value={passwordConfirmation}
-          onChange={(e) => setPasswordConfirmation(e.target.value)}
-          required
-          disabled={loading}
+        <FormField
+          control={form.control}
+          name="passwordConfirmation"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-gray-700 font-semibold">
+                パスワード（確認）
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-400"
+                  disabled={isPending || form.formState.isSubmitting}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
         />
-      </div>
       {error && <div className="text-red-500 text-sm text-center">{error}</div>}
       {success && (
         <div className="text-green-600 text-sm text-center">{success}</div>
       )}
-      <button
-        type="submit"
-        className="w-full bg-green-600 hover:bg-green-700 text-white font-bold py-2 rounded transition disabled:opacity-50"
-        disabled={loading}
-      >
-        {loading ? "送信中..." : "新規登録"}
-      </button>
+        <Button
+          type="submit"
+          className="w-full bg-green-600 hover:bg-green-700 text-white font-bold py-2 rounded transition disabled:opacity-50"
+          disabled={form.formState.isSubmitting}
+        >
+          {isPending ? "送信中..." : "新規登録"}
+        </Button>
       <div className="text-center mt-2">
         <a href="/sign_in" className="text-green-500 hover:underline text-sm">
           すでにアカウントをお持ちの方はこちら
         </a>
       </div>
-    </form>
+      </form>
+    </Form>
   );
 }

--- a/next/src/components/ui/button.tsx
+++ b/next/src/components/ui/button.tsx
@@ -5,26 +5,27 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
       },
     },
     defaultVariants: {
@@ -34,24 +35,25 @@ const buttonVariants = cva(
   }
 )
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean
-}
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Button.displayName = "Button"
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
 
 export { Button, buttonVariants }

--- a/next/src/components/ui/form.tsx
+++ b/next/src/components/ui/form.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  useFormState,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        ref={ref}
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  )
+})
+FormItem.displayName = "FormItem"
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+}
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : props.children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-destructive text-sm", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/next/src/components/ui/label.tsx
+++ b/next/src/components/ui/label.tsx
@@ -2,25 +2,23 @@
 
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
-const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-)
-
-const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
-    ref={ref}
-    className={cn(labelVariants(), className)}
-    {...props}
-  />
-))
-Label.displayName = LabelPrimitive.Root.displayName
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
 export { Label }


### PR DESCRIPTION
## 概要
React Hook FormのForm APIパターンへの移行と、認証機能のServer Actions対応を実施しました。

## 主な変更内容

### 1. React Hook Form API移行
- shadcn/ui Formコンポーネントを導入
- 全フォームをFormProvider/FormFieldパターンに移行
  - ClientGoalForm
  - ClientRecordForm
  - ClientYearlyGoalForm
  - SignInForm
  - SignUpForm

### 2. Server Actions対応
- useActionStateからuseTransitionへ移行（React 19推奨パターン）
- 新しいServer Actions作成（prevStateパラメータなし）
  - `createRunningRecord`
  - `updateMonthlyGoal`
  - `updateYearlyGoal`

### 3. 認証機能のServer Actions移行
- `auth-actions.ts`を新規作成
  - `signInAction`: サーバーサイドでのログイン処理
  - `signUpAction`: サーバーサイドでのユーザー登録
  - `signOutAction`: サーバーサイドでのログアウト処理
- セキュリティとパフォーマンスの向上

### 4. バグ修正
- ハイドレーションエラーを解消（ClientRunningCalendar）
- モーダル再オープン問題を修正
- NaN警告を解消（空文字列の適切な処理）
- カレンダー日付選択の不具合を修正
- uncontrolled input警告を解消

## テスト内容
- [x] フォーム入力とバリデーション動作確認
- [x] モーダルの開閉動作確認
- [x] 日付選択機能の動作確認
- [x] ログイン/ログアウト動作確認
- [x] ユーザー登録動作確認

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/code)