### PR TITLE
同じ日に複数の走行記録を登録できる機能を追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,14 +18,14 @@
       "Bash(ls:*)",
       "Bash(docker-compose exec next npm run lint:*)",
       "Bash(rm:*)",
-      "Bash(git add:*)",
       "Bash(git pull:*)",
       "Bash(gh issue:*)",
       "Bash(cp:*)",
       "Bash(gh pr view:*)",
       "Bash(git stash:*)",
       "Bash(docker-compose exec:*)",
-      "WebFetch(domain:react-hook-form.com)"
+      "WebFetch(domain:react-hook-form.com)",
+      "Bash(source:*)"
     ],
     "deny": []
   },

--- a/next/src/app/components/DashboardStatistics.tsx
+++ b/next/src/app/components/DashboardStatistics.tsx
@@ -12,7 +12,7 @@ interface DashboardStatisticsProps {
   goal: number;
   yearGoal: number;
   yearGoalProgress: number;
-  totalRecords: number;
+  monthlyRunDays: number;
 }
 
 export default function DashboardStatistics({
@@ -22,7 +22,7 @@ export default function DashboardStatistics({
   goal,
   yearGoal,
   yearGoalProgress,
-  totalRecords
+  monthlyRunDays
 }: DashboardStatisticsProps) {
   const [monthlyGoalModalOpen, setMonthlyGoalModalOpen] = useState(false);
   const [yearlyGoalModalOpen, setYearlyGoalModalOpen] = useState(false);
@@ -44,7 +44,7 @@ export default function DashboardStatistics({
         goal={goal}
         yearGoal={yearGoal}
         yearGoalProgress={yearGoalProgress}
-        totalRecords={totalRecords}
+        monthlyRunDays={monthlyRunDays}
         onYearlyGoalClick={handleYearlyGoalClick}
         onMonthlyGoalClick={handleMonthlyGoalClick}
       />

--- a/next/src/app/components/RunningChart.tsx
+++ b/next/src/app/components/RunningChart.tsx
@@ -82,10 +82,6 @@ export default function RunningChart({
     );
   };
 
-  const goToCurrentMonth = () => {
-    setCurrentViewDate(new Date());
-  };
-
   // タイムゾーン安全な日付文字列フォーマット関数
   const formatDateString = (date: Date): string => {
     const year = date.getFullYear();
@@ -151,9 +147,9 @@ export default function RunningChart({
     const currentDate = new Date(viewYear, viewMonth, day);
     const dateStr = formatDateString(currentDate);
 
-    // その日の走行記録を探す
-    const dayRecord = records.find((record) => record.date === dateStr);
-    const dayDistance = dayRecord ? Number(dayRecord.distance || 0) : 0;
+    // その日の全ての走行記録を集計
+    const dayRecords = records.filter((record) => record.date === dateStr);
+    const dayDistance = dayRecords.reduce((sum, record) => sum + Number(record.distance || 0), 0);
 
     // 累積距離を更新（今日までのデータのみ）
     if (day <= displayEndDay) {
@@ -192,12 +188,12 @@ export default function RunningChart({
     labels,
     datasets: [
       {
-        label: `${monthDisplayName}累積走行距離`,
+        label: `${monthDisplayName}の走行距離`,
         data: cumulativeData,
         borderColor: "rgb(34, 197, 94)",
         backgroundColor: "rgba(34, 197, 94, 0.1)",
         fill: true,
-        tension: 0.4,
+        tension: 0,
         pointBorderColor: "rgb(34, 197, 94)",
         pointBackgroundColor: "white",
         pointBorderWidth: 2,
@@ -205,7 +201,7 @@ export default function RunningChart({
         pointHoverRadius: 6,
       },
       {
-        label: `${monthDisplayName}目標ペース`,
+        label: `${monthDisplayName}の目標ペース`,
         data: goalLineData,
         borderColor: "rgb(239, 68, 68)",
         backgroundColor: "rgba(239, 68, 68, 0.1)",
@@ -277,11 +273,11 @@ export default function RunningChart({
               const diff = context.parsed.y - goalValue;
               const status =
                 diff >= 0 ? `+${diff.toFixed(1)}km 🔥` : `${diff.toFixed(1)}km`;
-              return `${monthDisplayName}累積: ${context.parsed.y.toFixed(
+              return `${monthDisplayName}の走行距離: ${context.parsed.y.toFixed(
                 1
               )} km (目標比: ${status})`;
             } else if (context.datasetIndex === 1) {
-              return `${monthDisplayName}目標ペース: ${context.parsed.y.toFixed(
+              return `${monthDisplayName}の目標ペース: ${context.parsed.y.toFixed(
                 1
               )} km`;
             } else {
@@ -318,7 +314,7 @@ export default function RunningChart({
         position: "left",
         title: {
           display: true,
-          text: `${monthDisplayName}累積距離 (km)`,
+          text: `${monthDisplayName}の走行距離 (km)`,
           font: {
             weight: "bold",
           },
@@ -377,15 +373,6 @@ export default function RunningChart({
           <h3 className="text-lg font-bold text-gray-800">
             {viewYear}年{viewMonth + 1}月
           </h3>
-          {(viewYear !== today.getFullYear() ||
-            viewMonth !== today.getMonth()) && (
-            <button
-              onClick={goToCurrentMonth}
-              className="px-2 py-1 text-xs bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
-            >
-              今月
-            </button>
-          )}
         </div>
 
         <button
@@ -401,7 +388,7 @@ export default function RunningChart({
       <div className="grid grid-cols-3 gap-4 text-sm text-gray-600">
         <div className="text-center">
           <div className="font-semibold text-emerald-600">
-            {monthDisplayName}累積
+            月間走行距離
           </div>
           <div className="text-lg font-bold">
             {viewMonthCumulative.toFixed(1)} km

--- a/next/src/app/components/ServerRunningDashboard.tsx
+++ b/next/src/app/components/ServerRunningDashboard.tsx
@@ -23,6 +23,18 @@ async function DashboardData() {
     const yearGoal = Number(yearlyGoal?.distance_goal || 500);
     const yearGoalProgress = yearGoal > 0 ? (thisYearDistance / yearGoal) * 100 : 0;
 
+    // 今月走った日数と記録回数を計算
+    const currentDate = new Date();
+    const currentMonth = currentDate.getMonth();
+    const currentYear = currentDate.getFullYear();
+    
+    const monthlyRecords = records.filter(record => {
+      const recordDate = new Date(record.date);
+      return recordDate.getMonth() === currentMonth && recordDate.getFullYear() === currentYear;
+    });
+    
+    const monthlyRunDays = new Set(monthlyRecords.map(record => record.date)).size;
+
     return (
       <div className="space-y-6">
         {/* 統計カード - クリック可能なカード */}
@@ -33,7 +45,7 @@ async function DashboardData() {
           goal={goal}
           yearGoal={yearGoal}
           yearGoalProgress={yearGoalProgress}
-          totalRecords={statistics.total_records}
+          monthlyRunDays={monthlyRunDays}
         />
 
         {/* カレンダーとアクションボタン */}

--- a/next/src/app/components/StatisticsCards.tsx
+++ b/next/src/app/components/StatisticsCards.tsx
@@ -5,7 +5,7 @@ interface StatisticsCardsProps {
   goal: number;
   yearGoal: number;
   yearGoalProgress: number;
-  totalRecords: number;
+  monthlyRunDays: number;
   onYearlyGoalClick: () => void;
   onMonthlyGoalClick: () => void;
 }
@@ -17,7 +17,7 @@ export default function StatisticsCards({
   goal,
   yearGoal,
   yearGoalProgress,
-  totalRecords,
+  monthlyRunDays,
   onYearlyGoalClick,
   onMonthlyGoalClick,
 }: StatisticsCardsProps) {
@@ -62,13 +62,13 @@ export default function StatisticsCards({
             </p>
             <p className="text-3xl font-bold">{thisMonthDistance.toFixed(1)} km</p>
             <p className="text-blue-100 text-xs mt-1">
-              頑張って続けましょう！
+            🔥 頑張って続けましょう！
             </p>
           </div>
           <div className="text-right">
             <span className="text-5xl text-blue-200 mb-2">⏱️</span>
             <div className="text-xs text-blue-100">
-              記録: {totalRecords}回
+              練習日: {monthlyRunDays}日
             </div>
           </div>
         </div>

--- a/rails/app/models/running_record.rb
+++ b/rails/app/models/running_record.rb
@@ -1,7 +1,7 @@
 class RunningRecord < ApplicationRecord
   belongs_to :user
 
-  validates :date, presence: true, uniqueness: { scope: :user_id }
+  validates :date, presence: true
   validates :distance, presence: true,
                        numericality: { greater_than: 0.1, less_than_or_equal_to: 100.0 }
 

--- a/rails/db/migrate/20250714112405_remove_unique_index_from_running_records.rb
+++ b/rails/db/migrate/20250714112405_remove_unique_index_from_running_records.rb
@@ -1,0 +1,6 @@
+class RemoveUniqueIndexFromRunningRecords < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :running_records, [:user_id, :date]
+    add_index :running_records, [:user_id, :date]
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_13_122847) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_14_112405) do
   create_table "monthly_goals", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "year", null: false
@@ -29,7 +29,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_13_122847) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["date"], name: "index_running_records_on_date"
-    t.index ["user_id", "date"], name: "index_running_records_on_user_id_and_date", unique: true
+    t.index ["user_id", "date"], name: "index_running_records_on_user_id_and_date"
     t.index ["user_id"], name: "index_running_records_on_user_id"
   end
 


### PR DESCRIPTION
## Summary
- 同じ日に複数の走行記録を登録できるようになりました
- 各所で複数記録の合計距離が正しく表示されます
- UIの改善も含まれています

## Changes
- 🗄️ データベースから日付とユーザーの一意制約を削除
- 📊 フロントエンドで複数記録の合計距離を表示
- 📅 カレンダーとチャートで複数記録を正しく集計
- 📈 統計表示を「走った日数」に変更
- 🏃 RecentRecordsから回数表示と最新タグを削除
- 📉 チャートの累積グラフを直線表示に変更

## Related Issue
Closes #39

## Test plan
- [x] 同じ日に複数の記録を登録できることを確認
- [x] カレンダーで合計距離が表示されることを確認
- [x] チャートで正しく累積が計算されることを確認
- [x] 統計が正しく表示されることを確認
- [x] RSpecテストが全てパスすることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)