### PR TITLE
feat: 未認証ユーザーの自動リダイレクト機能を実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,7 +28,8 @@
       "Bash(source:*)",
       "Bash(find:*)",
       "Bash(docker-compose:*)",
-      "mcp__playwright__browser_navigate"
+      "mcp__playwright__browser_navigate",
+      "Bash(unset GH_TOKEN)"
     ],
     "deny": []
   },

--- a/next/src/app/actions/auth-actions.ts
+++ b/next/src/app/actions/auth-actions.ts
@@ -39,7 +39,7 @@ export async function signInAction(formData: FormData) {
           path: '/',
         };
 
-        cookieStore.set('access_token', accessToken, cookieOptions);
+        cookieStore.set('access-token', accessToken, cookieOptions);
         cookieStore.set('client', client, cookieOptions);
         cookieStore.set('uid', uid, cookieOptions);
       }
@@ -116,7 +116,7 @@ export async function signOutAction() {
     const cookieStore = await cookies();
     
     // 認証情報を取得
-    const accessToken = cookieStore.get('access_token')?.value;
+    const accessToken = cookieStore.get('access-token')?.value;
     const client = cookieStore.get('client')?.value;
     const uid = cookieStore.get('uid')?.value;
 
@@ -133,14 +133,14 @@ export async function signOutAction() {
     }
 
     // Next.js側でもクッキーをクリア（開発環境での確実な削除のため）
-    cookieStore.delete('access_token');
+    cookieStore.delete('access-token');
     cookieStore.delete('client');
     cookieStore.delete('uid');
   } catch (error) {
     console.error('Sign out error:', error);
     // エラーが発生してもクッキーはクリアする
     const cookieStore = await cookies();
-    cookieStore.delete('access_token');
+    cookieStore.delete('access-token');
     cookieStore.delete('client');
     cookieStore.delete('uid');
   }

--- a/next/src/app/sign_in/SignInForm.tsx
+++ b/next/src/app/sign_in/SignInForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -18,6 +18,7 @@ type SignInFormData = z.infer<typeof signInSchema>;
 
 export default function SignInForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [error, setError] = useState("");
   const [isPending, startTransition] = useTransition();
   
@@ -40,7 +41,9 @@ export default function SignInForm() {
       const result = await signInAction(formData);
 
       if (result.success) {
-        router.push("/");
+        // リダイレクト元のURLがある場合はそこに戻る（middlewareと連携）
+        const from = searchParams.get('from');
+        router.push(from || "/");
       } else {
         setError(result.error || "ログインに失敗しました");
       }

--- a/next/src/app/sign_in/page.tsx
+++ b/next/src/app/sign_in/page.tsx
@@ -1,6 +1,14 @@
+import { redirect } from 'next/navigation';
+import { getAuthStatus } from '@/lib/server-auth';
 import SignInForm from "./SignInForm";
 
-export default function SignInPage() {
+export default async function SignInPage() {
+  // 既にログイン済みの場合はダッシュボードへリダイレクト
+  const isAuthenticated = await getAuthStatus();
+  if (isAuthenticated) {
+    redirect('/');
+  }
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-100 to-blue-200">
       <div className="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">

--- a/next/src/app/sign_up/page.tsx
+++ b/next/src/app/sign_up/page.tsx
@@ -1,6 +1,14 @@
+import { redirect } from 'next/navigation';
+import { getAuthStatus } from '@/lib/server-auth';
 import SignUpForm from "./SignUpForm";
 
-export default function SignUpPage() {
+export default async function SignUpPage() {
+  // 既にログイン済みの場合はダッシュボードへリダイレクト
+  const isAuthenticated = await getAuthStatus();
+  if (isAuthenticated) {
+    redirect('/');
+  }
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-100 to-blue-200">
       <div className="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">

--- a/next/src/lib/server-api.ts
+++ b/next/src/lib/server-api.ts
@@ -41,7 +41,7 @@ async function serverApiCall(endpoint: string, options: RequestInit = {}) {
   const url = `${API_BASE_URL}${endpoint}`;
   
   // クッキーから認証情報を取得
-  const accessToken = cookieStore.get('access_token')?.value;
+  const accessToken = cookieStore.get('access-token')?.value;
   const client = cookieStore.get('client')?.value;
   const uid = cookieStore.get('uid')?.value;
   
@@ -62,6 +62,16 @@ async function serverApiCall(endpoint: string, options: RequestInit = {}) {
   const response = await fetch(url, defaultOptions);
   
   if (!response.ok) {
+    // 401 Unauthorized の場合は特別な処理
+    if (response.status === 401) {
+      // 認証エラーをより詳細に記録
+      console.error('Authentication failed:', {
+        endpoint,
+        hasAccessToken: !!accessToken,
+        hasClient: !!client,
+        hasUid: !!uid
+      });
+    }
     throw new Error(`API Error: ${response.status} ${response.statusText}`);
   }
   

--- a/next/src/lib/server-auth.ts
+++ b/next/src/lib/server-auth.ts
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 
 export async function getAuthStatus() {
   const cookieStore = await cookies();
-  const token = cookieStore.get("access_token")?.value;
+  const token = cookieStore.get("access-token")?.value;
   const client = cookieStore.get("client")?.value;
   const uid = cookieStore.get("uid")?.value;
   return !!(token && client && uid);
@@ -11,7 +11,7 @@ export async function getAuthStatus() {
 export async function getAuthTokens() {
   const cookieStore = await cookies();
   return {
-    token: cookieStore.get("access_token")?.value,
+    token: cookieStore.get("access-token")?.value,
     client: cookieStore.get("client")?.value,
     uid: cookieStore.get("uid")?.value,
   };

--- a/next/src/middleware.ts
+++ b/next/src/middleware.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// 認証が不要なパス（公開ページ）
+const publicPaths = [
+  '/sign_in',
+  '/sign_up',
+];
+
+// 認証チェックをスキップするパス
+const excludePaths = [
+  '/api',
+  '/_next',
+  '/favicon.ico',
+  '/robots.txt',
+  '/sitemap.xml',
+];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // 除外パスの場合は何もしない
+  if (excludePaths.some(path => pathname.startsWith(path))) {
+    return NextResponse.next();
+  }
+
+  // 公開パスの場合は何もしない
+  if (publicPaths.some(path => pathname === path)) {
+    return NextResponse.next();
+  }
+
+  // 認証トークンの確認
+  const accessToken = request.cookies.get('access-token');
+  const client = request.cookies.get('client');
+  const uid = request.cookies.get('uid');
+
+  // 認証トークンが全て存在しない場合はログインページへリダイレクト
+  if (!accessToken || !client || !uid) {
+    const signInUrl = new URL('/sign_in', request.url);
+    // 元のURLをクエリパラメータとして保持（将来的な実装用）
+    signInUrl.searchParams.set('from', pathname);
+    return NextResponse.redirect(signInUrl);
+  }
+
+  return NextResponse.next();
+}
+
+// ミドルウェアを適用するパスの設定
+export const config = {
+  // 全てのパスに適用（除外パスは関数内で処理）
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - *.png, *.jpg, *.jpeg, *.gif, *.webp (image files)
+     * - *.js, *.css (static assets)
+     */
+    '/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:png|jpg|jpeg|gif|webp|js|css|ico)).*)',
+  ],
+};

--- a/rails/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/rails/app/controllers/api/v1/auth/registrations_controller.rb
@@ -10,8 +10,8 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   private
 
     def set_auth_cookies_from_headers
-      set_auth_cookie(:access_token, response.headers["access-token"])
-      set_auth_cookie(:client, response.headers["client"])
-      set_auth_cookie(:uid, response.headers["uid"])
+      set_auth_cookie("access-token", response.headers["access-token"])
+      set_auth_cookie("client", response.headers["client"])
+      set_auth_cookie("uid", response.headers["uid"])
     end
 end

--- a/rails/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/rails/app/controllers/api/v1/auth/sessions_controller.rb
@@ -11,15 +11,15 @@ class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
     def set_auth_cookies
       if @resource&.persisted? && response.status == 200
         auth_headers_data = @resource.create_new_auth_token
-        set_auth_cookie(:access_token, auth_headers_data["access-token"])
-        set_auth_cookie(:client, auth_headers_data["client"])
-        set_auth_cookie(:uid, auth_headers_data["uid"])
+        set_auth_cookie("access-token", auth_headers_data["access-token"])
+        set_auth_cookie("client", auth_headers_data["client"])
+        set_auth_cookie("uid", auth_headers_data["uid"])
       end
     end
 
     def clear_auth_cookies
-      clear_auth_cookie(:access_token)
-      clear_auth_cookie(:client)
-      clear_auth_cookie(:uid)
+      clear_auth_cookie("access-token")
+      clear_auth_cookie("client")
+      clear_auth_cookie("uid")
     end
 end

--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -19,13 +19,13 @@ class ApplicationController < ActionController::API
     end
 
     def auth_cookies_present?
-      request.cookies["access_token"].present? &&
+      request.cookies["access-token"].present? &&
         request.cookies["client"].present? &&
         request.cookies["uid"].present?
     end
 
     def set_auth_headers_from_cookie_values
-      request.headers["access-token"] = request.cookies["access_token"]
+      request.headers["access-token"] = request.cookies["access-token"]
       request.headers["client"] = request.cookies["client"]
       request.headers["uid"] = request.cookies["uid"]
       request.headers["token-type"] = "Bearer"


### PR DESCRIPTION
## Summary
Issue #44「ログインしてない時にリダイレクトさせる」の実装を完了しました。

## 実装内容

### 🔐 認証ミドルウェア
- `middleware.ts`を作成し、未認証ユーザーを自動的にログインページへリダイレクト
- 保護されたルートへのアクセスを制御
- 静的ファイル（画像、CSS、JS等）へのアクセスは除外

### 🔄 リダイレクト機能
- ログイン時に元のURLを`from`パラメータとして保持
- ログイン成功後は元のページへ自動的に戻る
- 認証済みユーザーがログインページにアクセスした場合はダッシュボードへリダイレクト

### 🔧 Cookie名の統一
- Rails側とNext.js側でcookie名を`access-token`（ハイフン）に統一
- DeviseTokenAuthのデフォルト設定と一致
- 全ファイルで一貫性のある命名規則を適用

## 変更ファイル

### Frontend (Next.js)
- `next/src/middleware.ts` - 認証ミドルウェア（新規作成）
- `next/src/app/sign_in/SignInForm.tsx` - リダイレクト処理を追加
- `next/src/app/sign_in/page.tsx` - 認証済みユーザーのリダイレクト
- `next/src/app/sign_up/page.tsx` - 認証済みユーザーのリダイレクト
- `next/src/app/actions/auth-actions.ts` - Cookie名を統一
- `next/src/lib/server-api.ts` - Cookie名を統一、デバッグ情報追加
- `next/src/lib/server-auth.ts` - Cookie名を統一

### Backend (Rails)
- `rails/app/controllers/application_controller.rb` - Cookie名を統一
- `rails/app/controllers/api/v1/auth/sessions_controller.rb` - Cookie名を統一
- `rails/app/controllers/api/v1/auth/registrations_controller.rb` - Cookie名を統一

## テスト結果
- ✅ 未認証でダッシュボードにアクセス → ログインページへリダイレクト
- ✅ ログイン成功後、元のページへ戻る
- ✅ 認証済みでログインページにアクセス → ダッシュボードへリダイレクト
- ✅ 静的ファイルへのアクセスは正常に処理
- ✅ RuboCop: no offenses detected
- ✅ ESLint: No warnings or errors

Closes #44

🤖 Generated with [Claude Code](https://claude.ai/code)