### PR TITLE
docker-compose.ymlにentrypointを追加し、entrypoint.shでの初期化処理を実行するように変更。entr…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - rails
     environment:
       - RAILS_ENV=development
+    # entrypoint.shで初期化処理を実行
+    entrypoint: ["/usr/bin/entrypoint.sh"]
   next:
     build:
       context: ./next

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_14_112405) do
+ActiveRecord::Schema[8.0].define(version: 20_250_714_112_405) do
   create_table "monthly_goals", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "year", null: false

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 20_250_714_112_405) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_14_112405) do
   create_table "monthly_goals", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "year", null: false
@@ -31,6 +31,127 @@ ActiveRecord::Schema[8.0].define(version: 20_250_714_112_405) do
     t.index ["date"], name: "index_running_records_on_date"
     t.index ["user_id", "date"], name: "index_running_records_on_user_id_and_date"
     t.index ["user_id"], name: "index_running_records_on_user_id"
+  end
+
+  create_table "solid_queue_blocked_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -70,5 +191,11 @@ ActiveRecord::Schema[8.0].define(version: 20_250_714_112_405) do
 
   add_foreign_key "monthly_goals", "users"
   add_foreign_key "running_records", "users"
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "yearly_goals", "users"
 end

--- a/rails/entrypoint.prod.sh
+++ b/rails/entrypoint.prod.sh
@@ -6,14 +6,32 @@ echo "Start entrypoint.prod.sh"
 echo "rm -f /myapp/tmp/pids/server.pid"
 rm -f /myapp/tmp/pids/server.pid
 
-echo "bundle exec rails db:create RAILS_ENV=production"
-bundle exec rails db:create RAILS_ENV=production
+# データベースが起動するまで待機
+echo "Waiting for database..."
+until bundle exec rails db:version RAILS_ENV=production 2>/dev/null; do
+  >&2 echo "Database is unavailable - sleeping"
+  sleep 1
+done
 
-echo "bundle exec rails db:migrate RAILS_ENV=production"
+# データベース作成（既に存在する場合はスキップ）
+echo "Creating database if not exists..."
+bundle exec rails db:create RAILS_ENV=production 2>/dev/null || true
+
+echo "Running database migrations..."
 bundle exec rails db:migrate RAILS_ENV=production
 
-echo "bundle exec rails db:seed RAILS_ENV=production"
-bundle exec rails db:seed RAILS_ENV=production
+# SolidQueueのテーブルが存在しない場合は作成
+echo "Checking SolidQueue tables..."
+if ! bundle exec rails runner "puts SolidQueue::Job.table_exists?" RAILS_ENV=production 2>/dev/null | grep -q "true"; then
+  echo "Creating SolidQueue tables..."
+  bundle exec rails db:queue:prepare RAILS_ENV=production
+fi
 
-echo "exec pumactl start"
-bundle exec pumactl start
+# シードデータ投入（初回のみ）
+if bundle exec rails runner "puts User.count" RAILS_ENV=production | grep -q "0"; then
+  echo "Running seed data..."
+  bundle exec rails db:seed RAILS_ENV=production
+fi
+
+echo "Starting puma server..."
+bundle exec puma -C config/puma.rb

--- a/rails/entrypoint.sh
+++ b/rails/entrypoint.sh
@@ -3,4 +3,22 @@ set -e
 
 rm -f /myapp/tmp/pids/server.pid
 
+# データベースが起動するまで待機
+echo "Waiting for database..."
+until bundle exec rails db:version 2>/dev/null; do
+  >&2 echo "Database is unavailable - sleeping"
+  sleep 1
+done
+
+# マイグレーション実行
+echo "Running database migrations..."
+bundle exec rails db:migrate
+
+# SolidQueueのテーブルが存在しない場合は作成
+echo "Checking SolidQueue tables..."
+if ! bundle exec rails runner "SolidQueue::Job.table_exists?" 2>/dev/null; then
+  echo "Creating SolidQueue tables..."
+  bundle exec rails db:queue:prepare
+fi
+
 exec "$@"

--- a/rails/entrypoint.worker.prod.sh
+++ b/rails/entrypoint.worker.prod.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+echo "Start entrypoint.worker.prod.sh"
+
+# データベースが起動するまで待機
+echo "Waiting for database..."
+until bundle exec rails db:version RAILS_ENV=production 2>/dev/null; do
+  >&2 echo "Database is unavailable - sleeping"
+  sleep 1
+done
+
+# SolidQueueのテーブルが存在するまで待機
+echo "Waiting for SolidQueue tables..."
+until bundle exec rails runner "exit(SolidQueue::Job.table_exists? ? 0 : 1)" RAILS_ENV=production 2>/dev/null; do
+  >&2 echo "SolidQueue tables are not ready - sleeping"
+  sleep 2
+done
+
+echo "Starting SolidQueue worker..."
+exec bundle exec rake solid_queue:start


### PR DESCRIPTION
…ypoint.prod.shではデータベースの起動待機、マイグレーション、SolidQueueテーブルの確認と作成、シードデータの投入を行う処理を追加。schema.rbにSolidQueue関連のテーブルを追加し、外部キー制約を設定。