### PR TITLE
fix: Rails環境に応じてメールのリダイレクトURLを自動設定 #65

### DIFF
--- a/rails/app/mailers/user_mailer.rb
+++ b/rails/app/mailers/user_mailer.rb
@@ -4,7 +4,7 @@ class UserMailer < ApplicationMailer
     @user = user
     @confirmation_token = confirmation_token
     @app_name = "Runmates"
-    @confirmation_url = "#{ENV.fetch("NEXT_PUBLIC_BASE_URL", "http://localhost:8000")}/confirm_email?token=#{@confirmation_token}"
+    @confirmation_url = "#{base_url}/confirm_email?token=#{@confirmation_token}"
 
     mail(
       to: @user.email,
@@ -28,11 +28,21 @@ class UserMailer < ApplicationMailer
     @user = user
     @reset_password_token = reset_password_token
     @app_name = "Runmates"
-    @reset_url = "#{ENV.fetch("NEXT_PUBLIC_BASE_URL", "http://localhost:8000")}/reset_password?token=#{@reset_password_token}"
+    @reset_url = "#{base_url}/reset_password?token=#{@reset_password_token}"
 
     mail(
       to: @user.email,
       subject: "【#{@app_name}】パスワードリセットのご案内",
     )
   end
+
+  private
+
+    def base_url
+      if Rails.env.production?
+        "https://runmates.net"
+      else
+        "http://localhost:8000"
+      end
+    end
 end


### PR DESCRIPTION
## 概要
Issue #65 で報告された、登録メールのリダイレクト先がlocalhostになっている問題を修正しました。

## 変更内容
- ✅ 環境変数の代わりに`Rails.env`で環境を判定するように変更
- ✅ production環境では `https://runmates.net` を使用
- ✅ それ以外の環境では `http://localhost:8000` を使用  
- ✅ `base_url`プライベートメソッドを追加してURLを一元管理

## 実装方針
環境変数を使わずに、Railsの環境（Rails.env）で直接判定する方式に変更しました。
これにより、環境変数の設定が不要になり、よりシンプルな実装になりました。

## 動作確認
- [ ] ローカル環境でメールのURLが `http://localhost:8000` になること
- [ ] 本番環境でメールのURLが `https://runmates.net` になること

Fixes #65

🤖 Generated with [Claude Code](https://claude.ai/code)