### PR TITLE
タイムゾーンをJSTに設定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       MYSQL_DATABASE: myapp_development
       MYSQL_USER: user
       MYSQL_PASSWORD: password
+      TZ: Asia/Tokyo
     ports:
       - "3307:3306"
     volumes:
@@ -24,6 +25,8 @@ services:
       - db
     tty: true
     stdin_open: true
+    environment:
+      TZ: Asia/Tokyo
   
   # SolidQueueワーカーコンテナ
   worker:
@@ -37,6 +40,7 @@ services:
       - rails
     environment:
       - RAILS_ENV=development
+      - TZ=Asia/Tokyo
     # entrypoint.shで初期化処理を実行
     entrypoint: ["/usr/bin/entrypoint.sh"]
   next:
@@ -50,6 +54,8 @@ services:
       - ./next:/app  # ホストマシンのカレントディレクトリ下の `next` フォルダをコンテナ内の `/app` にマウントします。
       - next_node_modules:/app/node_modules  # 名前付きボリューム `next_node_modules` でnode_modulesを管理
       - next_build:/app/.next  # 名前付きボリューム `next_build` で.nextディレクトリを管理
+    environment:
+      TZ: Asia/Tokyo
     ports:
       - "8000:3000"  # ホストのポート8000をコンテナのポート3000にフォワードします。Next.jsのデフォルトポート3000が外部の8000ポートでアクセス可能になります。
 

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -36,6 +36,10 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    
+    # タイムゾーンを日本時間に設定
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
 
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -36,9 +36,9 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-    
+
     # タイムゾーンを日本時間に設定
-    config.time_zone = 'Tokyo'
+    config.time_zone = "Tokyo"
     config.active_record.default_timezone = :local
 
     # Only loads a smaller set of middleware suitable for API only apps.

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_14_112405) do
+ActiveRecord::Schema[8.0].define(version: 20_250_714_112_405) do
   create_table "monthly_goals", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "year", null: false

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 20_250_714_112_405) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_14_112405) do
   create_table "monthly_goals", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "year", null: false


### PR DESCRIPTION
## 概要
開発環境と本番環境の時間のずれを解消するため、全てのDockerコンテナとRailsアプリケーションのタイムゾーンを日本時間（JST）に設定しました。

## 関連Issue
Fixes #69

## 変更内容

### 1. docker-compose.yml
各サービスに`TZ: Asia/Tokyo`環境変数を追加：
- db（MySQL）
- rails
- worker
- next

### 2. rails/config/application.rb
```ruby
config.time_zone = 'Tokyo'
config.active_record.default_timezone = :local
```

## 動作確認
✅ 全コンテナで`date`コマンドがJSTを表示
✅ Railsコンソールで以下を確認：
- Time.zone: (GMT+09:00) Tokyo
- Time.current: JST時刻
- Time.now: JST時刻

## テスト結果
- ✅ RSpec: 全125件のテストがパス
- ✅ RuboCop: 違反なし（自動修正適用済み）
- ✅ ESLint: エラー・警告なし

## 解決される問題
- 月が変わっても先月のデータが表示される問題（#69）は、タイムゾーンのずれが原因の可能性があったため、この修正により解決される可能性があります

🤖 Generated with [Claude Code](https://claude.ai/code)