### PR TITLE
[A11y] アクセシビリティ警告の解消とキーボード操作の実装 #98

### DIFF
--- a/next/src/features/running/components/ClientRunningCalendar.tsx
+++ b/next/src/features/running/components/ClientRunningCalendar.tsx
@@ -158,9 +158,21 @@ export default function ClientRunningCalendar({
           const isWeekend = date.getDay() === 0 || date.getDay() === 6;
 
           return (
-            <div
+            <button
               key={index}
               onClick={() => isCurrentMonth && handleDateClick(date)}
+              onKeyDown={(e) => {
+                if (isCurrentMonth && (e.key === 'Enter' || e.key === ' ')) {
+                  e.preventDefault();
+                  handleDateClick(date);
+                }
+              }}
+              disabled={!isCurrentMonth}
+              aria-label={`${date.getFullYear()}年${
+                date.getMonth() + 1
+              }月${date.getDate()}日${
+                hasRun ? `、${totalDistance.toFixed(1)}km走行済み` : ''
+              }${isToday ? '、今日' : ''}`}
               className={[
                 'relative flex h-12 items-center justify-center rounded-lg text-sm transition-all duration-200',
                 !isCurrentMonth
@@ -192,7 +204,7 @@ export default function ClientRunningCalendar({
                 className="absolute inset-0 rounded-lg bg-blue-400 opacity-20"
                 style={{ display: isToday && !hasRun ? 'block' : 'none' }}
               />
-            </div>
+            </button>
           );
         })}
       </div>

--- a/next/src/features/running/components/RecentRecords.tsx
+++ b/next/src/features/running/components/RecentRecords.tsx
@@ -106,10 +106,19 @@ export default function RecentRecords({ statistics }: RecentRecordsProps) {
 
                 {/* 同じ日の記録一覧 */}
                 {group.records.map((record) => (
-                  <div
+                  <button
                     key={record.id}
                     onClick={() => handleRecordClick(record)}
-                    className="group flex cursor-pointer items-center justify-between rounded-lg bg-gray-50 p-3 transition-colors hover:bg-gray-100"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleRecordClick(record);
+                      }
+                    }}
+                    aria-label={`${record.date}の${Number(
+                      record.distance,
+                    ).toFixed(1)}kmの記録を編集`}
+                    className="group flex w-full cursor-pointer items-center justify-between rounded-lg bg-gray-50 p-3 text-left transition-colors hover:bg-gray-100"
                   >
                     <div className="flex items-center space-x-3">
                       <div className="text-emerald-600 group-hover:animate-pulse">
@@ -139,7 +148,7 @@ export default function RecentRecords({ statistics }: RecentRecordsProps) {
                         />
                       </svg>
                     </div>
-                  </div>
+                  </button>
                 ))}
               </div>
             ))

--- a/next/src/features/running/components/StatisticsCards.tsx
+++ b/next/src/features/running/components/StatisticsCards.tsx
@@ -24,9 +24,16 @@ export default function StatisticsCards({
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
       {/* 今年の総走行距離 - クリック可能 */}
-      <div
-        className="group transform cursor-pointer rounded-xl bg-gradient-to-br from-emerald-400 to-emerald-600 p-6 text-white shadow-lg transition-all duration-300 hover:scale-105"
+      <button
+        className="group transform cursor-pointer rounded-xl bg-gradient-to-br from-emerald-400 to-emerald-600 p-6 text-white shadow-lg transition-all duration-300 hover:scale-105 w-full text-left"
         onClick={onYearlyGoalClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onYearlyGoalClick();
+          }
+        }}
+        aria-label={`今年の総走行距離: ${thisYearDistance.toFixed(1)}km、年間目標: ${yearGoal}km、達成率: ${yearGoalProgress.toFixed(0)}%`}
       >
         <div className="flex items-start justify-between">
           <div>
@@ -58,7 +65,7 @@ export default function StatisticsCards({
             </div>
           </div>
         </div>
-      </div>
+      </button>
 
       {/* 今月の走行距離 */}
       <div className="rounded-xl bg-gradient-to-br from-blue-400 to-blue-600 p-6 text-white shadow-lg">
@@ -85,9 +92,16 @@ export default function StatisticsCards({
       </div>
 
       {/* 目標達成率 - クリック可能 */}
-      <div
-        className="group transform cursor-pointer rounded-xl bg-gradient-to-br from-purple-400 to-purple-600 p-6 text-white shadow-lg transition-all duration-300 hover:scale-105"
+      <button
+        className="group transform cursor-pointer rounded-xl bg-gradient-to-br from-purple-400 to-purple-600 p-6 text-white shadow-lg transition-all duration-300 hover:scale-105 w-full text-left"
         onClick={onMonthlyGoalClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onMonthlyGoalClick();
+          }
+        }}
+        aria-label={`月間目標達成率: ${goalAchievementRate.toFixed(0)}%、目標: ${goal}km、現在: ${thisMonthDistance.toFixed(1)}km`}
       >
         <div className="flex items-start justify-between">
           <div>
@@ -122,7 +136,7 @@ export default function StatisticsCards({
             </div>
           </div>
         </div>
-      </div>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
Issue #98で報告されたアクセシビリティ警告を解消し、キーボード操作とスクリーンリーダー対応を実装しました。

## 変更内容

### 1. ClientRunningCalendar.tsx
- カレンダーの日付セルを`<div>`から`<button>`に変更
- キーボードイベント（Enter/Space）を追加
- aria-labelで日付と走行情報を説明（例：「2024年12月25日、5.2km走行済み、今日」）
- 選択不可の日付に`disabled`属性を設定

### 2. RecentRecords.tsx
- 記録リストを`<div>`から`<button>`に変更
- キーボードイベントを追加
- aria-labelで記録の詳細情報を説明
- `w-full text-left`でレイアウトを維持

### 3. StatisticsCards.tsx
- 統計カードを`<div>`から`<button>`に変更
- 年間/月間目標カードにキーボードイベントを追加
- aria-labelで統計情報を詳しく説明

## 結果

### アクセシビリティ警告の解消
**Before:**
```
jsx-a11y/click-events-have-key-events: 6件
jsx-a11y/no-static-element-interactions: 6件
jsx-a11y/heading-has-content: 1件（実際は存在せず）
```

**After:**
```
✅ アクセシビリティ警告: 0件
```

### 新機能
- ✅ キーボードのみでの操作が可能
- ✅ スクリーンリーダー対応
- ✅ フォーカス表示で選択中の要素が明確

### テスト結果
- Rails: 全161件のテストが成功
- RuboCop: 問題なし
- ESLint: アクセシビリティ警告は解消（セキュリティ警告のみ残存）

## 挙動の変更
- **マウスユーザー**: 変更なし（見た目・操作感は同じ）
- **キーボードユーザー**: Tab/Enter/Spaceで操作可能に
- **スクリーンリーダー**: 適切な情報が読み上げられるように

Fixes #98

🤖 Generated with [Claude Code](https://claude.ai/code)