### PR TITLE
refactor: 変数名をupdatedRecordsからfreshMonthRecordsに変更

### DIFF
--- a/next/src/features/running/actions/running-actions.ts
+++ b/next/src/features/running/actions/running-actions.ts
@@ -115,12 +115,12 @@ export async function createRunningRecord(
     const year = recordDate.getFullYear();
     const month = recordDate.getMonth() + 1;
     
-    const updatedRecords = await apiCall<RunRecord[]>(
+    const freshMonthRecords = await apiCall<RunRecord[]>(
       `/running_records?year=${year}&month=${month}`
     );
 
     revalidatePath('/');
-    return { success: true, data: updatedRecords };
+    return { success: true, data: freshMonthRecords };
   } catch (error) {
     console.error('Failed to add running record:', error);
     return { success: false, error: '記録の追加に失敗しました' };

--- a/next/src/features/running/components/dashboard/DashboardWithCalendar.tsx
+++ b/next/src/features/running/components/dashboard/DashboardWithCalendar.tsx
@@ -31,13 +31,13 @@ export default function DashboardWithCalendar({
     setRecordFormOpen(true);
   };
 
-  const handleFormClose = (updatedRecords?: RunRecord[]) => {
+  const handleFormClose = (freshMonthRecords?: RunRecord[]) => {
     setRecordFormOpen(false);
     setSelectedDate('');
     
     // Server Actionから返された最新データで更新
-    if (updatedRecords) {
-      setCurrentMonthRecords(updatedRecords);
+    if (freshMonthRecords) {
+      setCurrentMonthRecords(freshMonthRecords);
     }
   };
 

--- a/next/src/features/running/components/forms/ClientRecordForm.tsx
+++ b/next/src/features/running/components/forms/ClientRecordForm.tsx
@@ -42,7 +42,7 @@ type RunningRecordFormData = {
 interface ClientRecordFormProps {
   selectedDate?: string;
   isOpen: boolean;
-  onClose: (updatedRecords?: RunRecord[]) => void;
+  onClose: (freshMonthRecords?: RunRecord[]) => void;
 }
 
 export default function ClientRecordForm({
@@ -72,14 +72,14 @@ export default function ClientRecordForm({
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
-  const handleClose = useCallback((updatedRecords?: RunRecord[]) => {
+  const handleClose = useCallback((freshMonthRecords?: RunRecord[]) => {
     form.reset({
       date: '',
       distance: '',
     });
     setError(null);
     if (onClose) {
-      onClose(updatedRecords);
+      onClose(freshMonthRecords);
     }
   }, [form, onClose]);
 


### PR DESCRIPTION
## 概要
Server Actionで最新データを取得する際の変数名を、より意図が明確な名前に変更しました。

## 変更理由
- `updatedRecords`は「更新された」という意味で、データ自体を変更したような誤解を招く可能性があった
- 実際には最新のデータを取得しているだけなので、`freshMonthRecords`（新鮮な月のレコード）という名前の方が適切

## 変更内容
以下のファイルで変数名を統一的に変更：
- `running-actions.ts`: Server Action内の変数名
- `ClientRecordForm.tsx`: onCloseハンドラーの引数名  
- `DashboardWithCalendar.tsx`: handleFormCloseの引数名

## テスト結果
- ✅ ESLintチェック: 問題なし
- ✅ Rails RSpec: 全164テスト成功（カバレッジ94.75%）
- ✅ Rubocop: 違反なし
- ✅ ビルド成功

## その他
軽微なリファクタリングのため、動作に影響はありません。

🤖 Generated with [Claude Code](https://claude.ai/code)