### PR TITLE
[Bug] Rswag UIのDeprecation Warningとテストの日付問題を修正

### DIFF
--- a/rails/config/initializers/rswag_ui.rb
+++ b/rails/config/initializers/rswag_ui.rb
@@ -9,7 +9,7 @@ if defined?(Rswag)
     # (under openapi_root) as JSON or YAML endpoints, then the list below should
     # correspond to the relative paths for those endpoints.
 
-    c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
+    c.openapi_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
 
     # 本番環境でのみBasic認証を有効化
     # if Rails.env.production?

--- a/rails/spec/requests/api/v1/running_records_spec.rb
+++ b/rails/spec/requests/api/v1/running_records_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe "Api::V1::RunningRecords", type: :request do
   describe "GET /api/v1/running_records" do
     context "認証済みユーザーの場合" do
       before do
-        create_list(:running_record, 3, user: user)
+        # 現在月の異なる日付で3つのレコードを作成
+        create(:running_record, user: user, date: Date.current.beginning_of_month)
+        create(:running_record, user: user, date: Date.current.beginning_of_month + 5.days)
+        create(:running_record, user: user, date: Date.current)
       end
 
       it "ランニングレコード一覧を返す" do

--- a/rails/spec/requests/api/v1/running_statistics_spec.rb
+++ b/rails/spec/requests/api/v1/running_statistics_spec.rb
@@ -7,12 +7,11 @@ RSpec.describe "Api::V1::RunningStatistics", type: :request do
   describe "GET /api/v1/running_statistics" do
     context "認証済みユーザーの場合" do
       before do
-        # 今年のレコードを作成
-        create(:running_record, user: user, date: Date.current) # デフォルト5.0km
-        create(:running_record, user: user, date: Date.current - 1.day, distance: 3.0)
-        create(:running_record, user: user, date: Date.current - 2.days, distance: 4.0)
-
-        # 今月のレコード（上記3つ含む）
+        # 今月のレコードを作成（月をまたがないように月の中間日付を使用）
+        middle_of_month = Date.current.beginning_of_month + 14.days
+        create(:running_record, user: user, date: middle_of_month, distance: 5.0)
+        create(:running_record, user: user, date: middle_of_month - 1.day, distance: 3.0)
+        create(:running_record, user: user, date: middle_of_month - 2.days, distance: 4.0)
         create(:running_record, user: user, date: Date.current.beginning_of_month, distance: 2.0)
 
         # 去年のレコード（長距離）


### PR DESCRIPTION
## 概要
RspecでDeprecation Warningが発生していた問題と、月初付近でテストが失敗する可能性がある問題を修正しました。

## 修正内容

### 1. Rswag UIのDeprecation Warning修正
- `swagger_endpoint`メソッドが非推奨となり、v3.0で`openapi_endpoint`に変更される警告が出ていました
- `rails/config/initializers/rswag_ui.rb`で該当メソッドを新しいメソッド名に変更

### 2. テストの日付問題修正
#### RunningRecordsのテスト
- ファクトリのデフォルト動作が`Date.current - n.days`のため、月初付近で実行すると月をまたぐ可能性がありました
- 明示的に現在月の日付を指定するように修正

#### RunningStatisticsのテスト
- 同様に月初付近で前月のデータが混入する可能性がありました
- 月の中間日付（15日前後）を基準にデータを作成するように修正

## テスト結果
- ✅ rspec: 164 examples, 0 failures
- ✅ rubocop: no offenses detected
- ✅ eslint: 警告1件のみ（既存のもの）
- ✅ カバレッジ: 94.75%維持

## 関連Issue
なし（Deprecation Warningの事前対応）

🤖 Generated with [Claude Code](https://claude.ai/code)