### PR TITLE
fix: Server Actionを使用してメールアドレス変更後のログアウト処理を改善

### DIFF
--- a/next/src/features/profile/components/ConfirmEmailChangeClient.tsx
+++ b/next/src/features/profile/components/ConfirmEmailChangeClient.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
+import { logoutAction } from '@/features/auth/actions/auth-actions';
+
 export default function ConfirmEmailChangeClient() {
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>(
     'loading',
@@ -38,21 +40,10 @@ export default function ConfirmEmailChangeClient() {
           setMessage('メールアドレスが変更されました');
           setNewEmail(data.email || '');
           
-          // ログアウトしてからログインページへリダイレクト
-          const logoutAndRedirect = async () => {
-            try {
-              await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/sign_out`, {
-                method: 'DELETE',
-                credentials: 'include',
-              });
-            } catch {
-              // ログアウトが失敗してもリダイレクトは行う
-            }
-            router.push('/login');
-          };
-          
-          // 5秒後にログアウトしてリダイレクト
-          setTimeout(logoutAndRedirect, 5000);
+          // 3秒後にログアウト（Server Action経由で確実にクッキーをクリア）
+          setTimeout(() => {
+            logoutAction();
+          }, 3000);
         } else {
           setStatus('error');
           setMessage(
@@ -108,7 +99,7 @@ export default function ConfirmEmailChangeClient() {
           セキュリティのため、新しいメールアドレスで再度ログインしてください。
         </p>
         <p className="mb-4 text-gray-600">
-          5秒後にログインページへ移動します。
+          3秒後にログインページへ移動します。
         </p>
         <Link
           href="/login"


### PR DESCRIPTION
## 概要
本番環境でメールアドレス変更後にログインページへ遷移しない問題を修正

## 問題の詳細
- メールアドレス変更後、古い認証クッキーが残っていた
- クライアント側からfetch APIでログアウトAPIを呼んでも、クッキーが確実に削除されなかった
- その結果、ログインページへリダイレクトしてもダッシュボードへ自動転送されていた

## 解決方法
- Server Actionの`logoutAction`を使用するように変更
- Server Actionはサーバー側で確実にクッキーを削除できる
- `redirect('/login')`により確実にログインページへ遷移

## 変更内容
1. `logoutAction`をインポート
2. fetch APIによる直接的なログアウト処理を削除
3. Server Action経由でログアウトを実行
4. タイマーを5秒から3秒に短縮

## テスト方法
1. メールアドレス変更リクエストを送信
2. 受信したメールのリンクをクリック
3. 変更成功メッセージが表示される
4. 3秒後に自動的にログアウトされログインページへ遷移することを確認
5. 新しいメールアドレスでログインできることを確認

## 関連Issue
Relates to #134

🤖 Generated with [Claude Code](https://claude.ai/code)