### PR TITLE
fix: クッキーのSameSite属性をLaxに統一

### DIFF
--- a/rails/app/controllers/concerns/auth_cookie_helper.rb
+++ b/rails/app/controllers/concerns/auth_cookie_helper.rb
@@ -18,8 +18,8 @@ module AuthCookieHelper
         value: value,
         httponly: true,
         secure: Rails.env.production?,
-        # サブドメイン間でクッキーを共有し、セキュリティを強化
-        same_site: Rails.env.production? ? :strict : :lax,
+        # サブドメイン間でクッキーを共有し、セキュリティとユーザビリティのバランスを取る
+        same_site: :lax,
         # 本番環境ではサブドメイン間でクッキーを共有
         domain: Rails.env.production? ? ".runmates.net" : nil,
         expires: expires,


### PR DESCRIPTION
## 概要
クッキーのSameSite属性を`Strict`から`Lax`に変更し、クライアントからのAPI呼び出しを可能にしました。

## 背景と問題
- 本番環境で`SameSite=Strict`に設定されていた
- メールアドレス変更後のログアウト処理などで、クライアントから直接APIを呼び出せない問題があった
- サブドメイン間（runmates.net と backend.runmates.net）の通信に制限があった

## 変更内容
### `rails/app/controllers/concerns/auth_cookie_helper.rb`
```ruby
# 変更前
same_site: Rails.env.production? ? :strict : :lax

# 変更後  
same_site: :lax
```

## SameSite属性について
| 属性 | 説明 | クロスサイト | セキュリティ |
|------|------|-------------|--------------|
| **Strict** | 最も厳格。同一サイトのみ | ❌ 送信されない | 最高 |
| **Lax** | トップレベルナビゲーションのGETは許可 | ⚠️ GETのみ | 高 |
| **None** | 制限なし（Secure必須） | ✅ すべて送信 | 低 |

## テスト結果
Playwrightを使用した検証で以下を確認：
- ✅ GET リクエスト: 成功（ユーザー情報取得）
- ✅ POST リクエスト: 成功（ランニング記録作成）
- ✅ DELETE リクエスト: 成功（ログアウト）
- ✅ 認証クッキーが正常に送信される

## 効果
- クライアントコンポーネントから直接APIを呼び出し可能に
- セキュリティとユーザビリティのバランスが向上
- メールアドレス変更後のログアウト処理が正常に動作

## チェックリスト
- [x] ESLint: パス（警告1件は既存）
- [x] Rubocop: パス
- [x] RSpec: 全167件パス（カバレッジ88.99%）
- [x] Playwrightで動作確認済み

## 関連Issue
Fixes #142

🤖 Generated with [Claude Code](https://claude.ai/code)