### PR TITLE
[Bug] メール認証URLのパス修正

### DIFF
--- a/rails/app/mailers/user_mailer.rb
+++ b/rails/app/mailers/user_mailer.rb
@@ -4,7 +4,7 @@ class UserMailer < ApplicationMailer
     @user = user
     @confirmation_token = confirmation_token
     @app_name = "Runmates"
-    @confirmation_url = "#{base_url}/confirm_email?token=#{@confirmation_token}"
+    @confirmation_url = "#{base_url}/confirm-email?token=#{@confirmation_token}"
 
     mail(
       to: @user.email,
@@ -29,7 +29,7 @@ class UserMailer < ApplicationMailer
     @user = user
     @reset_password_token = reset_password_token
     @app_name = "Runmates"
-    @reset_url = "#{base_url}/reset_password?token=#{@reset_password_token}"
+    @reset_url = "#{base_url}/reset-password?token=#{@reset_password_token}"
 
     mail(
       to: @user.email,

--- a/rails/spec/mailers/user_mailer_spec.rb
+++ b/rails/spec/mailers/user_mailer_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe UserMailer, type: :mailer do
 
     it "リセットトークンを含むリンクを含むこと" do
       expect(mail.html_part.body.encoded).to include(reset_token)
-      expect(mail.html_part.body.encoded).to include("/reset_password?token=#{reset_token}")
+      expect(mail.html_part.body.encoded).to include("/reset-password?token=#{reset_token}")
       expect(mail.text_part.body.encoded).to include(reset_token)
-      expect(mail.text_part.body.encoded).to include("/reset_password?token=#{reset_token}")
+      expect(mail.text_part.body.encoded).to include("/reset-password?token=#{reset_token}")
     end
 
     it "有効期限の警告を含むこと" do


### PR DESCRIPTION
## 🐛 問題の概要
新規登録時の確認メールから認証を行うと、誤ったURLにアクセスしてログインページにリダイレクトされる問題がありました。

## 🔍 原因
メーラーで生成されるURLのパスがフロントエンドの実際のルートと一致していませんでした：
- メーラー: `/confirm_email` (アンダースコア)
- フロントエンド: `/confirm-email` (ハイフン)

## ✅ 修正内容
1. **メール認証URL**: `/confirm_email` → `/confirm-email`
2. **パスワードリセットURL**: `/reset_password` → `/reset-password`
3. 関連するテストも同様に修正

## 📋 テスト
- ✅ ESLint: エラーなし（警告1件のみ）
- ✅ Rubocop: 違反なし
- ✅ RSpec: 全167テスト成功

## 🎯 影響範囲
- `rails/app/mailers/user_mailer.rb`: URLパスの修正
- `rails/spec/mailers/user_mailer_spec.rb`: テストの期待値を修正

## 🔄 動作確認方法
1. 新規ユーザー登録を実行
2. 確認メールのリンクをクリック
3. 正常に`/confirm-email`ページが表示され、メール認証が完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)