### PR TITLE
[Bug] 本番環境でのAPI接続エラーを修正

### DIFF
--- a/next/src/lib/api/client-base.ts
+++ b/next/src/lib/api/client-base.ts
@@ -14,7 +14,11 @@ export async function apiCall<T>(
 ): Promise<ApiResponse<T>> {
   try {
     const baseUrl =
-      process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api/v1';
+      process.env.NEXT_PUBLIC_API_URL || 
+      (typeof window !== 'undefined' && 
+       (window.location.hostname === 'runmates.net')
+        ? 'https://backend.runmates.net/api/v1' 
+        : 'http://localhost:3000/api/v1');
     const url = `${baseUrl}${endpoint}`;
 
     const response = await fetch(url, {
@@ -27,6 +31,15 @@ export async function apiCall<T>(
     });
 
     if (!response.ok) {
+      // エラーの詳細をログ出力
+      if (typeof window !== 'undefined') {
+        console.error('API Error Details:', {
+          status: response.status,
+          statusText: response.statusText,
+          url: url,
+          endpoint: endpoint
+        });
+      }
       throw new Error(`API error: ${response.status}`);
     }
 


### PR DESCRIPTION
## 🐛 問題の概要
本番環境で月を変更した際にランニング記録が表示されない問題を修正しました。

## 🔍 原因
APIエンドポイントのURLが間違っていました：
- 誤: `https://runmates.net/api/v1` 
- 正: `https://backend.runmates.net/api/v1`

これにより401認証エラーが発生し、データ取得に失敗していました。

## ✅ 修正内容

### 1. APIエンドポイントの修正
- `next/src/lib/api/client-base.ts`のフォールバックURLを正しいバックエンドURLに変更
- 本番環境判定を`window.location.hostname === 'runmates.net'`のみに簡略化

### 2. 推奨事項
Vercelの環境変数に以下を設定することを推奨：
```
NEXT_PUBLIC_API_URL=https://backend.runmates.net/api/v1
NEXT_PUBLIC_BASE_URL=https://runmates.net
```

## 📋 テスト結果
- ✅ ESLint: エラーなし（警告1件のみ）
- ✅ Rubocop: 違反なし
- ✅ RSpec: 全167テスト成功（カバレッジ89.19%）

## 🎯 影響範囲
- クライアントサイドのAPI呼び出しのみ影響
- サーバーアクションは影響なし（異なるURL設定を使用）

## 🔄 動作確認方法
1. 本番環境にアクセス
2. カレンダーで月を切り替え
3. ランニング記録が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)