### PR TITLE
[Bug] 本番環境のAPI URLをハードコード化

### DIFF
--- a/next/src/lib/api/client-base.ts
+++ b/next/src/lib/api/client-base.ts
@@ -13,9 +13,21 @@ export async function apiCall<T>(
   options?: RequestInit,
 ): Promise<ApiResponse<T>> {
   try {
+    // 環境変数を無視して直接URLを指定
     const baseUrl =
-      process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api/v1';
+      typeof window !== 'undefined' && window.location.hostname === 'runmates.net'
+        ? 'https://backend.runmates.net/api/v1' 
+        : 'http://localhost:3000/api/v1';
     const url = `${baseUrl}${endpoint}`;
+
+    // デバッグログ
+    if (typeof window !== 'undefined') {
+      console.log('🔍 API Request Debug:');
+      console.log('  Hostname:', window.location.hostname);
+      console.log('  Base URL:', baseUrl);
+      console.log('  Full URL:', url);
+      console.log('  Credentials:', 'include');
+    }
 
     const response = await fetch(url, {
       ...options,


### PR DESCRIPTION
## 概要
本番環境での401エラーを解決するため、API URLを環境変数に依存せず直接指定するよう修正しました。

## 問題の詳細
本番環境のサーバーログから判明した事実：
- ❌ Cookieが全く送信されていない（`Cookies received: 空`）
- ❌ 認証トークンも送信されていない
- 原因: 環境変数 `NEXT_PUBLIC_API_URL` が未設定の可能性

## 修正内容
### `next/src/lib/api/client-base.ts`
環境変数を無視してホスト名で判定：
```typescript
const baseUrl =
  typeof window !== 'undefined' && window.location.hostname === 'runmates.net'
    ? 'https://backend.runmates.net/api/v1' 
    : 'http://localhost:3000/api/v1';
```

デバッグログも追加：
- ホスト名
- 使用するBase URL
- 完全なリクエストURL
- Credentials設定

## テスト結果
- ✅ ESLint: Passed（既存の警告1件のみ）

## デプロイ後の確認事項
1. ブラウザコンソールでデバッグログを確認
2. 正しいURLが使用されているか確認
3. Cookieが送信されるか確認

## 関連
- #154 - 月変更時に401エラーが発生する問題
- #158 - Rails側のデバッグログ追加

🤖 Generated with [Claude Code](https://claude.ai/code)