### PR TITLE
[Bug] CookieのSameSite属性を本番環境でNoneに設定

### DIFF
--- a/rails/app/controllers/concerns/auth_cookie_helper.rb
+++ b/rails/app/controllers/concerns/auth_cookie_helper.rb
@@ -18,8 +18,9 @@ module AuthCookieHelper
         value: value,
         httponly: true,
         secure: Rails.env.production?,
-        # サブドメイン間でクッキーを共有し、セキュリティとユーザビリティのバランスを取る
-        same_site: :lax,
+        # 本番環境ではクロスサイトリクエストでもクッキーを送信するためnoneに設定
+        # 開発環境では同一サイトなのでlaxで十分
+        same_site: Rails.env.production? ? :none : :lax,
         # 本番環境ではサブドメイン間でクッキーを共有
         domain: Rails.env.production? ? ".runmates.net" : nil,
         expires: expires,


### PR DESCRIPTION
## 概要
クロスドメイン認証エラーを解決するため、本番環境でのCookie設定を修正しました。

## 問題の詳細
### 症状
- runmates.net → backend.runmates.net へのAPIリクエストで401エラー
- カレンダーで月を変更すると認証エラーでデータが表示されない

### 原因の特定
1. サーバーログ（PR #158のデバッグログ）で確認：
   - リクエストは届いている
   - しかし`Cookies received: 空`
   - 認証Cookieが全く送信されていない

2. ブラウザのDevToolsで確認：
   - Cookieは存在（access-token, client, uid）
   - ドメイン: runmates.net
   - **SameSite: Lax** ← これが原因！

3. 現在のコード確認：
   - `same_site: :lax`のまま
   - Laxではクロスサイトリクエストで送信されない

## 修正内容
### `rails/app/controllers/concerns/auth_cookie_helper.rb`
```ruby
# 変更前
same_site: :lax

# 変更後  
same_site: Rails.env.production? ? :none : :lax
```

- 本番環境: SameSite=None（クロスサイトで送信可能）
- 開発環境: SameSite=Lax（従来通り）

## テスト結果
- ✅ RSpec: 167 examples, 0 failures (Coverage: 89.45%)
- ✅ Rubocop: No offenses detected

## デプロイ後の確認
1. Cookieをクリアして再ログイン
2. 新しいCookieのSameSite属性が「None」になることを確認
3. 月変更時に401エラーが発生しないことを確認

## 関連
- #154 - 月変更時に401エラーが発生する問題
- #158 - Rails側のデバッグログ追加
- #159 - API URLのハードコード化

🤖 Generated with [Claude Code](https://claude.ai/code)