### PR TITLE
fix: Partitioned Cookieを無効化してクロスドメイン認証を修正

### DIFF
--- a/rails/app/controllers/concerns/auth_cookie_helper.rb
+++ b/rails/app/controllers/concerns/auth_cookie_helper.rb
@@ -14,7 +14,7 @@ module AuthCookieHelper
     end
 
     def auth_cookie_options(value, expires)
-      {
+      options = {
         value: value,
         httponly: true,
         secure: Rails.env.production?,
@@ -26,5 +26,11 @@ module AuthCookieHelper
         expires: expires,
         path: "/",
       }
+
+      # Partitioned Cookieを無効化（クロスサイトで送信されるようにする）
+      # Rails 7.1以降でpartitionedオプションがサポートされている場合のみ設定
+      options[:partitioned] = false if Rails.env.production?
+
+      options
     end
 end


### PR DESCRIPTION
## 概要
本番環境でクッキーがクロスドメイン（runmates.net → backend.runmates.net）で送信されない問題を修正しました。

## 問題
- 月を変更するとランニング記録が表示されない（401エラー）
- ブラウザのDevToolsで確認すると、クッキーに`Partition Key: https://runmates.net`が設定されていた
- CHIPS（Cookies Having Independent Partitioned State）により、クッキーがrunmates.netドメインに限定されていた
- `SameSite=None`は既に設定済みだったが、Partition Keyがクロスドメイン送信を阻害

## 解決策
`auth_cookie_helper.rb`に`partitioned: false`オプションを追加：
- Partition Keyが削除される
- サブドメイン間（runmates.net ↔ backend.runmates.net）でクッキーが共有可能になる

## 変更内容
- `rails/app/controllers/concerns/auth_cookie_helper.rb`
  - 本番環境でのみ`partitioned: false`を設定

## テスト結果
✅ **RSpec**: 167 examples, 0 failures
✅ **Rubocop**: no offenses detected  
✅ **ESLint**: 1 warning（既存のもの）

## デプロイ後の対応
**重要**: デプロイ後、ユーザーは一度ログアウトして再度ログインする必要があります（既存のPartitioned Cookieを削除するため）

## 関連Issue
- #154（月を変更すると記録が表示されない問題）

## チェックリスト
- [x] コード変更が完了
- [x] テストがすべて通過
- [x] Lintチェックが通過
- [x] 本番環境への影響を考慮

🤖 Generated with Claude Code (https://claude.ai/code)