### PR TITLE
未使用のpingメソッドを削除

### DIFF
--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -4,10 +4,6 @@ class ApplicationController < ActionController::API
 
   before_action :set_auth_headers_from_cookies
 
-  def ping
-    render json: { message: "pong" }
-  end
-
   private
 
     def set_auth_headers_from_cookies


### PR DESCRIPTION
## 概要
ApplicationControllerに定義されていた未使用のpingメソッドを削除しました。

## 変更内容
- `rails/app/controllers/application_controller.rb`から`ping`メソッドを削除
- `routes.rb`にルーティング設定がなく、使用されていないメソッドでした

## テスト結果
- ✅ rspec: 167 examples, 0 failures
- ✅ rubocop: 91 files inspected, no offenses detected
- ✅ eslint: 問題なし（既存のWarningのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)