### PR TITLE
Solid Queueのワーカー設定を調整

### DIFF
--- a/rails/config/solid_queue.yml
+++ b/rails/config/solid_queue.yml
@@ -34,15 +34,15 @@ production:
   # 本番環境では負荷に応じて調整
   dispatchers:
     - polling_interval: 1
-      batch_size: 1000
-  
+      batch_size: 200
+ 
   workers:
     # 通常のジョブ用ワーカー
     - queues: ["default", "mailers"]
-      threads: 5
-      processes: 2
+      threads: 1
+      processes: 1
     
     # 優先度の高いジョブ用ワーカー
     - queues: ["urgent"]
-      threads: 3
+      threads: 1
       processes: 1

--- a/rails/entrypoint.prod.sh
+++ b/rails/entrypoint.prod.sh
@@ -3,6 +3,9 @@ set -e
 
 echo "Start entrypoint.prod.sh"
 
+export WEB_CONCURRENCY=${WEB_CONCURRENCY:-1}
+export RAILS_MAX_THREADS=${RAILS_MAX_THREADS:-2}
+
 echo "rm -f /myapp/tmp/pids/server.pid"
 rm -f /myapp/tmp/pids/server.pid
 


### PR DESCRIPTION
## 概要
- Solid Queueのdispatcherとworkerの並列度を本番負荷に合わせて縮小
- Puma起動前にWEB_CONCURRENCYとRAILS_MAX_THREADSのデフォルトを設定

## 関連Issue
Fixes #N/A

## 変更内容
- [x] Solid Queueのdispatchers設定をbatch_size 200に更新
- [x] Solid Queueのworkerスレッド/プロセス数を最小化
- [x] entrypointでWEB_CONCURRENCYとRAILS_MAX_THREADSのデフォルト値を定義

## 動作確認
- [ ] ローカル環境での動作確認
- [x] テストの実行
- [x] Lintチェック

## スクリーンショット（UIの変更がある場合）
該当なし

## レビューポイント
- 本番向けのSolid Queue並列度が期待通りか
- Puma起動時の環境変数設定が影響範囲に適しているか

## その他
なし
