### PR TITLE
middlewareをproxyへ移行

### DIFF
--- a/next/src/proxy.ts
+++ b/next/src/proxy.ts
@@ -19,7 +19,7 @@ const excludePaths = [
   '/sitemap.xml',
 ];
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // 除外パスの場合は何もしない


### PR DESCRIPTION
## 概要
- Next.js 16 で推奨される proxy.ts へ移行し、middleware 警告を解消しました。

## 関連Issue
Fixes #180

## 変更内容
- [x] middleware.ts を proxy.ts へリネームし、エクスポート関数を proxy に変更
- [x] 既存の公開パス・除外パス・matcher 設定を維持
- [x] Lint / Build / RuboCop / RSpec を実行して警告が消えていることを確認

## 動作確認
- [x] docker compose exec next npm run lint
- [x] docker compose run --rm next npm run build
- [x] docker compose exec rails bundle exec rubocop
- [x] docker compose exec rails bundle exec rspec

## スクリーンショット（UIの変更がある場合）
- なし

## レビューポイント
- proxy.ts への移行後も認証判定ロジックや matcher が期待通りか

## その他
- ビルド時には cookies を利用する動的ルートに関する警告が引き続き表示されますが、本対応の範囲外として現状維持です。
