### PR TITLE
fix: mark / and /settings/profile as dynamic

### DIFF
--- a/next/src/app/page.tsx
+++ b/next/src/app/page.tsx
@@ -1,6 +1,9 @@
 import HeaderNav from '@/components/layout/HeaderNav';
 import ServerRunningDashboard from '@/features/running/components/dashboard/ServerRunningDashboard';
 
+// ServerRunningDashboardがcookies()を参照するServer Componentを内包するためビルド時プリレンダー不可
+export const dynamic = 'force-dynamic';
+
 export default async function HomePage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-100 to-blue-200">

--- a/next/src/app/settings/profile/page.tsx
+++ b/next/src/app/settings/profile/page.tsx
@@ -4,6 +4,9 @@ import Link from 'next/link';
 import { getUserProfile } from '@/features/profile/actions/get-user-profile';
 import { EmailChangeForm } from '@/features/profile/components/EmailChangeForm';
 
+// getUserProfile内でcookies()を参照するため静的生成ができず動的レンダリングを明示
+export const dynamic = 'force-dynamic';
+
 export default async function ProfilePage() {
   const { user, error } = await getUserProfile();
 


### PR DESCRIPTION
## 概要
- `/` と `/settings/profile` が `cookies()` を利用する Server Component を内包しているため静的プリレンダーできないので、`export const dynamic = 'force-dynamic'` を付与しNext.jsに動的ルートであると明示しました。
- `next build` を実行し、`DYNAMIC_SERVER_USAGE` エラーが解消されることを確認しています。

## 動作確認
- `docker compose run --rm next npm run build`
