### PR TITLE
fix: ログイン直後のPerformanceエラーを解消

### DIFF
--- a/next/src/app/(auth)/create-account/page.tsx
+++ b/next/src/app/(auth)/create-account/page.tsx
@@ -1,15 +1,6 @@
-import { redirect } from 'next/navigation';
-
 import CreateAccountForm from '@/features/auth/components/forms/CreateAccountForm';
-import { getAuthStatus } from '@/features/auth/lib/server';
 
-export default async function CreateAccountPage() {
-  // 既にログイン済みの場合はダッシュボードへリダイレクト
-  const isAuthenticated = await getAuthStatus();
-  if (isAuthenticated) {
-    redirect('/');
-  }
-
+export default function CreateAccountPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-green-100 to-blue-200 px-4 py-8">
       <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-lg md:p-8">

--- a/next/src/app/(auth)/login/page.tsx
+++ b/next/src/app/(auth)/login/page.tsx
@@ -1,22 +1,17 @@
-import { redirect } from 'next/navigation';
+import { Suspense } from 'react';
 
 import LoginForm from '@/features/auth/components/forms/LoginForm';
-import { getAuthStatus } from '@/features/auth/lib/server';
 
-export default async function LoginPage() {
-  // 既にログイン済みの場合はダッシュボードへリダイレクト
-  const isAuthenticated = await getAuthStatus();
-  if (isAuthenticated) {
-    redirect('/');
-  }
-
+export default function LoginPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-green-100 to-blue-200 px-4 py-8">
       <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-lg md:p-8">
         <h2 className="mb-6 text-center text-2xl font-bold text-green-700 md:text-3xl">
           ログイン
         </h2>
-        <LoginForm />
+        <Suspense fallback={null}>
+          <LoginForm />
+        </Suspense>
       </div>
     </div>
   );

--- a/next/src/features/auth/components/forms/LoginForm.tsx
+++ b/next/src/features/auth/components/forms/LoginForm.tsx
@@ -2,7 +2,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState, useTransition } from 'react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -29,7 +29,7 @@ export default function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [error, setError] = useState('');
-  const [isPending, startTransition] = useTransition();
+  const [isPending, setIsPending] = useState(false);
 
   const form = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
@@ -41,8 +41,9 @@ export default function LoginForm() {
 
   const onSubmit = async (data: LoginFormData) => {
     setError('');
+    setIsPending(true);
 
-    startTransition(async () => {
+    try {
       const formData = new FormData();
       formData.append('email', data.email);
       formData.append('password', data.password);
@@ -56,7 +57,9 @@ export default function LoginForm() {
       } else {
         setError(result.error || 'ログインに失敗しました');
       }
-    });
+    } finally {
+      setIsPending(false);
+    }
   };
 
   return (
@@ -108,7 +111,7 @@ export default function LoginForm() {
         <Button
           type="submit"
           className="w-full rounded bg-green-600 py-2 font-bold text-white transition hover:bg-green-700 disabled:opacity-50"
-          disabled={form.formState.isSubmitting}
+          disabled={isPending || form.formState.isSubmitting}
         >
           {isPending ? '送信中...' : 'ログイン'}
         </Button>

--- a/next/src/proxy.ts
+++ b/next/src/proxy.ts
@@ -27,18 +27,36 @@ export function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 公開パスの場合は何もしない
-  if (publicPaths.some((path) => pathname === path)) {
-    return NextResponse.next();
-  }
+  const isPublicPath = publicPaths.some((path) => pathname === path);
 
   // 認証トークンの確認
   const accessToken = request.cookies.get('access-token');
   const client = request.cookies.get('client');
   const uid = request.cookies.get('uid');
+  const isAuthenticated = Boolean(accessToken && client && uid);
+
+  // 認証済みで公開パスへアクセスした場合はダッシュボードへ戻す
+  if (isAuthenticated && isPublicPath) {
+    const redirectUrl = new URL(request.url);
+    const returnPath = request.nextUrl.searchParams.get('from');
+
+    redirectUrl.pathname =
+      returnPath &&
+      returnPath.startsWith('/') &&
+      !publicPaths.includes(returnPath)
+        ? returnPath
+        : '/';
+    redirectUrl.search = '';
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  // 公開パスの場合はここで終了
+  if (isPublicPath) {
+    return NextResponse.next();
+  }
 
   // 認証トークンが全て存在しない場合はログインページへリダイレクト
-  if (!accessToken || !client || !uid) {
+  if (!isAuthenticated) {
     const loginUrl = new URL('/login', request.url);
     // 元のURLをクエリパラメータとして保持（将来的な実装用）
     loginUrl.searchParams.set('from', pathname);


### PR DESCRIPTION
## 概要
- `/login` と `/create-account` を静的コンポーネント化し、`Suspense` を用いたCSRバイパスに変更
- ログインフォームの送信処理を `useState` ベースのpending管理に変更し、Dev Overlayの `performance.measure` エラーを解消
- ミドルウェア(`proxy.ts`)で公開ページアクセス時のリダイレクト制御を一元化し、認証済みユーザーの導線を安定化

### Suspenseを用いたCSRバイパスについて
- `useSearchParams()` はクライアント専用フックのため、該当コンポーネントはCSRへの切り替えが必要です
- ルートを静的レンダリングしつつ、一部をCSRに切り替えるには `<Suspense>` で囲って Next.js に「ここから内側はクライアント側で描画する」と明示します
- 今回 `LoginForm` を `<Suspense>` 配下に移したことで、初期HTMLはサーバーで高速に出しつつ、フォーム内部ではクライアント状態や検索クエリを扱えるようにしています

## 関連Issue
Fixes #186

## 変更内容
- [x] ログイン/新規登録ページからサーバーサイドの認証チェックを除去
- [x] LoginFormの送信処理を `useTransition` から通常の非同期制御に変更
- [x] `proxy.ts` で公開パスアクセス時のリダイレクトを制御し、認証状態を一元管理

## 動作確認
- [x] `docker compose exec next npm run lint`
- [x] `docker compose exec rails bundle exec rubocop`
- [x] `docker compose exec rails bundle exec rspec`

## スクリーンショット（UIの変更がある場合）
UI変更なし

## レビューポイント
- ミドルウェアによるリダイレクト制御が期待通りか
- Suspense化によるCSR挙動に問題がないか

## その他
- Next.js 16 の Dev Overlay が `performance.measure('LoginPage', …)` を行う際のクラッシュを解消する目的の修正です。
