### PR TITLE
RSpecのtype推論を有効化しRubocop拡張を追加

### DIFF
--- a/rails/.rubocop.yml
+++ b/rails/.rubocop.yml
@@ -1,5 +1,9 @@
 plugins:
+  - rubocop-factory_bot
+  - rubocop-faker
   - rubocop-rails
+  - rubocop-rspec
+  - rubocop-rspec_rails
 
 inherit_from:
   - config/rubocop/rubocop.yml
@@ -48,4 +52,3 @@ Rails/ReversibleMigration:
 Rails/Output:
   Exclude:
     - 'lib/tasks/**/*'
-

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -77,9 +77,11 @@ group :development, :test do
   gem "shoulda-matchers"
 
   # rubocop を使えるようにする。
+  gem "rubocop-factory_bot"
   gem "rubocop-faker"
   gem "rubocop-rails"
   gem "rubocop-rspec"
+  gem "rubocop-rspec_rails"
 
   # テストカバレッジを測定・レポート生成
   gem "simplecov", require: false

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -403,6 +403,9 @@ GEM
     rubocop-ast (1.45.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
+    rubocop-factory_bot (2.28.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
     rubocop-faker (1.3.0)
       faker (>= 2.12.0)
       lint_roller (~> 1.1)
@@ -416,6 +419,10 @@ GEM
     rubocop-rspec (3.6.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
+    rubocop-rspec_rails (2.32.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
+      rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     shoulda-matchers (6.5.0)
@@ -492,9 +499,11 @@ DEPENDENCIES
   rspec-rails
   rswag-api
   rswag-ui
+  rubocop-factory_bot
   rubocop-faker
   rubocop-rails
   rubocop-rspec
+  rubocop-rspec_rails
   shoulda-matchers
   simplecov
   solid_queue

--- a/rails/spec/factories/monthly_goals.rb
+++ b/rails/spec/factories/monthly_goals.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :monthly_goal do
-    association :user
+    user
     year { Date.current.year }
     month { Date.current.month }
     distance_goal { 100.0 }

--- a/rails/spec/factories/running_plans.rb
+++ b/rails/spec/factories/running_plans.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :running_plan do
-    association :user
+    user
     sequence(:date) {|n| Date.new(2025, 1, 1) + n.days }
     planned_distance { 5.0 }
     memo { "マイランプラン" }

--- a/rails/spec/factories/running_records.rb
+++ b/rails/spec/factories/running_records.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :running_record do
-    association :user
+    user
     sequence(:date) {|n| Date.new(2025, 1, 1) + n.days }
     distance { 5.0 }
 

--- a/rails/spec/factories/yearly_goals.rb
+++ b/rails/spec/factories/yearly_goals.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :yearly_goal do
-    association :user
+    user
     year { Date.current.year }
     distance_goal { 1200.0 }
 

--- a/rails/spec/jobs/user_mailer_job_spec.rb
+++ b/rails/spec/jobs/user_mailer_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe UserMailerJob, type: :job do
+RSpec.describe UserMailerJob do
   include ActiveJob::TestHelper
 
   let(:user) { create(:user) }

--- a/rails/spec/mailers/user_mailer_spec.rb
+++ b/rails/spec/mailers/user_mailer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe UserMailer, type: :mailer do
+RSpec.describe UserMailer do
   let(:user) { create(:user, email: "test@example.com", name: "テストユーザー") }
 
   describe "#welcome_email" do

--- a/rails/spec/models/monthly_goal_spec.rb
+++ b/rails/spec/models/monthly_goal_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe MonthlyGoal, type: :model do
+RSpec.describe MonthlyGoal do
   describe "アソシエーション" do
     it { should belong_to(:user) }
   end

--- a/rails/spec/models/running_plan_spec.rb
+++ b/rails/spec/models/running_plan_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe RunningPlan, type: :model do
+RSpec.describe RunningPlan do
   describe "アソシエーション" do
     it { should belong_to(:user) }
   end

--- a/rails/spec/models/running_record_spec.rb
+++ b/rails/spec/models/running_record_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe RunningRecord, type: :model do
+RSpec.describe RunningRecord do
   describe "アソシエーション" do
     it { should belong_to(:user) }
   end

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe User, type: :model do
+RSpec.describe User do
   context "factoryのデフォルト設定に従った場合" do
     let(:user) { create(:user) }
 

--- a/rails/spec/models/yearly_goal_spec.rb
+++ b/rails/spec/models/yearly_goal_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe YearlyGoal, type: :model do
+RSpec.describe YearlyGoal do
   describe "アソシエーション" do
     it { should belong_to(:user) }
   end

--- a/rails/spec/rails_helper.rb
+++ b/rails/spec/rails_helper.rb
@@ -63,7 +63,7 @@ RSpec.configure do |config|
   # behaviour is considered legacy and will be removed in a future version.
   #
   # To enable this behaviour uncomment the line below.
-  # config.infer_spec_type_from_file_location!
+  config.infer_spec_type_from_file_location!
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!

--- a/rails/spec/requests/api/v1/auth/confirmations_spec.rb
+++ b/rails/spec/requests/api/v1/auth/confirmations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::Auth::Confirmations", type: :request do
+RSpec.describe "Api::V1::Auth::Confirmations" do
   describe "GET /api/v1/auth/confirmation" do
     context "有効な確認トークンの場合" do
       let(:user) { create(:user, confirmed_at: nil) }
@@ -28,7 +28,7 @@ RSpec.describe "Api::V1::Auth::Confirmations", type: :request do
       it "エラーレスポンスを返すこと" do
         get "/api/v1/auth/confirmation", params: { confirmation_token: "invalid_token" }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
 
         json_response = response.parsed_body
         expect(json_response["success"]).to be false
@@ -43,7 +43,7 @@ RSpec.describe "Api::V1::Auth::Confirmations", type: :request do
       it "エラーレスポンスを返すこと" do
         get "/api/v1/auth/confirmation", params: { confirmation_token: confirmation_token }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
 
         json_response = response.parsed_body
         expect(json_response["success"]).to be false

--- a/rails/spec/requests/api/v1/auth/email_confirmations_spec.rb
+++ b/rails/spec/requests/api/v1/auth/email_confirmations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::Auth::EmailConfirmations", type: :request do
+RSpec.describe "Api::V1::Auth::EmailConfirmations" do
   describe "GET /api/v1/auth/email_confirmation" do
     let(:user) { create(:user, email: "old@example.com", confirmed_at: 1.day.ago) }
     let(:new_email) { "new@example.com" }

--- a/rails/spec/requests/api/v1/auth/passwords_spec.rb
+++ b/rails/spec/requests/api/v1/auth/passwords_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::Auth::Passwords", type: :request do
+RSpec.describe "Api::V1::Auth::Passwords" do
   let(:user) { create(:user, email: "test@example.com") }
 
   describe "POST /api/v1/auth/password" do
@@ -85,7 +85,7 @@ RSpec.describe "Api::V1::Auth::Passwords", type: :request do
       it "エラーレスポンスを返すこと" do
         put "/api/v1/auth/password", params: invalid_params
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
 
         json_response = response.parsed_body
         expect(json_response["success"]).to be false
@@ -108,7 +108,7 @@ RSpec.describe "Api::V1::Auth::Passwords", type: :request do
       it "エラーレスポンスを返すこと" do
         put "/api/v1/auth/password", params: mismatched_params
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
 
         json_response = response.parsed_body
         expect(json_response["success"]).to be false
@@ -134,7 +134,7 @@ RSpec.describe "Api::V1::Auth::Passwords", type: :request do
       it "エラーレスポンスを返すこと" do
         put "/api/v1/auth/password", params: empty_password_params
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
 
         json_response = response.parsed_body
         expect(json_response["success"]).to be false

--- a/rails/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/rails/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+RSpec.describe "Api::V1::Auth::Registrations" do
   describe "POST /api/v1/auth" do
     let(:valid_params) do
       {
@@ -59,7 +59,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
 
       it "エラーレスポンスを返すこと" do
         post "/api/v1/auth", params: invalid_params
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         json = response.parsed_body
         expect(json["status"]).to eq("error")
       end

--- a/rails/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/rails/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::Auth::Sessions", type: :request do
+RSpec.describe "Api::V1::Auth::Sessions" do
   describe "POST /api/v1/auth/sign_in" do
     context "確認済みユーザーの場合" do
       let(:user) { create(:user, password: "password123") }

--- a/rails/spec/requests/api/v1/current/users_spec.rb
+++ b/rails/spec/requests/api/v1/current/users_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::Current::Users", type: :request do
+RSpec.describe "Api::V1::Current::Users" do
   describe "GET api/v1/current/user" do
     subject { get(api_v1_current_user_path, headers:) }
 
@@ -82,7 +82,7 @@ RSpec.describe "Api::V1::Current::Users", type: :request do
                  params: { password: "wrongpassword" },
                  headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           res = response.parsed_body
           expect(res["errors"]).to include("パスワードが正しくありません")
           expect(User.exists?(current_user.id)).to be true
@@ -93,7 +93,7 @@ RSpec.describe "Api::V1::Current::Users", type: :request do
         it "エラーが返される" do
           delete api_v1_current_user_path, headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           res = response.parsed_body
           expect(res["errors"]).to include("パスワードが必要です")
           expect(User.exists?(current_user.id)).to be true
@@ -114,7 +114,7 @@ RSpec.describe "Api::V1::Current::Users", type: :request do
                    headers: headers
           }.not_to change { User.count }
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           res = response.parsed_body
           expect(res["errors"]).to include("アカウントの削除に失敗しました")
           expect(Rails.logger).to have_received(:error).with(/User deletion failed/)

--- a/rails/spec/requests/api/v1/current_monthly_goal_spec.rb
+++ b/rails/spec/requests/api/v1/current_monthly_goal_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::CurrentMonthlyGoal", type: :request do
+RSpec.describe "Api::V1::CurrentMonthlyGoal" do
   let(:user) { create(:user) }
   let(:headers) { user.create_new_auth_token }
   let(:current_year) { Date.current.year }
@@ -130,7 +130,7 @@ RSpec.describe "Api::V1::CurrentMonthlyGoal", type: :request do
                params: { monthly_goal: { year: current_year, month: current_month, distance_goal: 0 } },
                headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
 
           json_response = response.parsed_body
           expect(json_response["errors"]).to be_present

--- a/rails/spec/requests/api/v1/current_yearly_goal_spec.rb
+++ b/rails/spec/requests/api/v1/current_yearly_goal_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::CurrentYearlyGoal", type: :request do
+RSpec.describe "Api::V1::CurrentYearlyGoal" do
   let(:user) { create(:user) }
   let(:headers) { user.create_new_auth_token }
   let(:current_year) { Date.current.year }
@@ -118,7 +118,7 @@ RSpec.describe "Api::V1::CurrentYearlyGoal", type: :request do
                params: { yearly_goal: { year: current_year, distance_goal: 0 } },
                headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
 
           json_response = response.parsed_body
           expect(json_response["errors"]).to be_present

--- a/rails/spec/requests/api/v1/monthly_goals_spec.rb
+++ b/rails/spec/requests/api/v1/monthly_goals_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::MonthlyGoals", type: :request do
+RSpec.describe "Api::V1::MonthlyGoals" do
   let(:user) { create(:user) }
   let(:headers) { user.create_new_auth_token }
 
@@ -99,7 +99,7 @@ RSpec.describe "Api::V1::MonthlyGoals", type: :request do
         it "422を返し、エラーメッセージを含む" do
           post "/api/v1/monthly_goals", params: invalid_params, headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = response.parsed_body
           expect(json["errors"]).to be_present
         end
@@ -113,7 +113,7 @@ RSpec.describe "Api::V1::MonthlyGoals", type: :request do
         it "422を返し、重複エラーを含む" do
           post "/api/v1/monthly_goals", params: valid_params, headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = response.parsed_body
           expect(json["errors"]).to be_present
           expect(json["errors"].join).to include("すでに存在")
@@ -164,7 +164,7 @@ RSpec.describe "Api::V1::MonthlyGoals", type: :request do
           patch "/api/v1/monthly_goals/#{monthly_goal.id}",
                 params: invalid_params, headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = response.parsed_body
           expect(json["errors"]).to be_present
         end

--- a/rails/spec/requests/api/v1/running_plans_spec.rb
+++ b/rails/spec/requests/api/v1/running_plans_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::RunningPlans", type: :request do
+RSpec.describe "Api::V1::RunningPlans" do
   let(:user) { create(:user) }
   let(:headers) { user.create_new_auth_token }
 
@@ -68,7 +68,7 @@ RSpec.describe "Api::V1::RunningPlans", type: :request do
 
         post "/api/v1/running_plans", params: invalid_params, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.parsed_body["errors"]).to be_present
       end
     end

--- a/rails/spec/requests/api/v1/running_records_spec.rb
+++ b/rails/spec/requests/api/v1/running_records_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::RunningRecords", type: :request do
+RSpec.describe "Api::V1::RunningRecords" do
   let(:user) { create(:user) }
   let(:headers) { user.create_new_auth_token }
 
@@ -154,7 +154,7 @@ RSpec.describe "Api::V1::RunningRecords", type: :request do
         it "422を返し、エラーメッセージを含む" do
           post "/api/v1/running_records", params: invalid_params, headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = response.parsed_body
           expect(json["errors"]).to be_present
         end
@@ -169,7 +169,7 @@ RSpec.describe "Api::V1::RunningRecords", type: :request do
 
           post "/api/v1/running_records", params: params, headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = response.parsed_body
           expect(json["errors"]).to include("日付は2025年1月1日以降の日付を入力してください")
         end
@@ -184,7 +184,7 @@ RSpec.describe "Api::V1::RunningRecords", type: :request do
 
           post "/api/v1/running_records", params: params, headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = response.parsed_body
           expect(json["errors"]).to include("日付はYYYY-MM-DD形式で入力してください")
         end
@@ -234,7 +234,7 @@ RSpec.describe "Api::V1::RunningRecords", type: :request do
           patch "/api/v1/running_records/#{running_record.id}",
                 params: invalid_params, headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = response.parsed_body
           expect(json["errors"]).to be_present
         end

--- a/rails/spec/requests/api/v1/running_statistics_spec.rb
+++ b/rails/spec/requests/api/v1/running_statistics_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::RunningStatistics", type: :request do
+RSpec.describe "Api::V1::RunningStatistics" do
   let(:user) { create(:user) }
   let(:headers) { user.create_new_auth_token }
 

--- a/rails/spec/requests/api/v1/yearly_goals_spec.rb
+++ b/rails/spec/requests/api/v1/yearly_goals_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::YearlyGoals", type: :request do
+RSpec.describe "Api::V1::YearlyGoals" do
   let(:user) { create(:user) }
   let(:headers) { user.create_new_auth_token }
 
@@ -98,7 +98,7 @@ RSpec.describe "Api::V1::YearlyGoals", type: :request do
         it "422を返し、エラーメッセージを含む" do
           post "/api/v1/yearly_goals", params: invalid_params, headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = response.parsed_body
           expect(json["errors"]).to be_present
         end
@@ -112,7 +112,7 @@ RSpec.describe "Api::V1::YearlyGoals", type: :request do
         it "422を返し、重複エラーを含む" do
           post "/api/v1/yearly_goals", params: valid_params, headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = response.parsed_body
           expect(json["errors"]).to be_present
           expect(json["errors"].join).to include("すでに存在")
@@ -163,7 +163,7 @@ RSpec.describe "Api::V1::YearlyGoals", type: :request do
           patch "/api/v1/yearly_goals/#{yearly_goal.id}",
                 params: invalid_params, headers: headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = response.parsed_body
           expect(json["errors"]).to be_present
         end

--- a/rails/spec/requests/health_check_spec.rb
+++ b/rails/spec/requests/health_check_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "HealthCheck", type: :request do
+RSpec.describe "HealthCheck" do
   describe "GET /api/v1/health_check" do
     subject { get(api_v1_health_check_path) }
 


### PR DESCRIPTION
## 概要
RSpecのspec種別推論を有効化し、Rubocopの拡張（factory_bot/rspec_rails）を追加しました。

## 関連Issue
Fixes #193

## 変更内容
- [x] RSpecのtype推論を有効化（spec配下の位置からtypeを自動付与）
- [x] Rubocop拡張（rubocop-factory_bot / rubocop-rspec_rails）を追加
- [x] rubocop -A の自動修正を反映

## 動作確認
- [x] ローカル環境での動作確認
- [x] テストの実行（rspec）
- [x] Lintチェック（eslint / rubocop）

## スクリーンショット（UIの変更がある場合）
なし

## レビューポイント
特になし

## その他
追加ライブラリの用途と使い方:
- rubocop-factory_bot: FactoryBotのLint強化。 配下で指摘が有効になります。
- rubocop-rspec_rails: RSpec + Rails向けCop追加。 や  のルールが強化されます。
