### PR TITLE
IaC棚卸しテンプレート追加

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,1 @@
+aws-infra-inventory.md


### PR DESCRIPTION
## 概要
Terraform化に向けたAWS構成の棚卸し用テンプレートを用意し、`terraform/` 配下に配置しました（テンプレート自体はgitignore対象）。

## 関連Issue
Refs #207

## 変更内容
- [x] `terraform/` にAWS構成の棚卸しテンプレート（穴埋め式）を追加
- [x] テンプレートファイルを `terraform/.gitignore` で除外
- [x] 運用時の記入を想定したセクション構成を整理

## 動作確認
- [x] ローカル環境での動作確認（ファイル作成と配置）
- [x] テストの実行（`docker-compose exec rails bundle exec rspec`）
- [x] Lintチェック（`docker-compose exec rails bundle exec rubocop` / `docker-compose exec next npm run lint`）

## スクリーンショット（UIの変更がある場合）
UI変更なし

## レビューポイント
テンプレートの項目構成が不足していないか確認いただきたいです。

## その他
ESLint実行時に baseline-browser-mapping の更新警告が出ましたが、チェックは成功しています。
