### PR TITLE
Route53とACMのTerraform化

### DIFF
--- a/terraform/envs/prod/route53_acm.tf
+++ b/terraform/envs/prod/route53_acm.tf
@@ -71,42 +71,32 @@ resource "aws_acm_certificate" "runmates" {
 // 手書きではなく自動で配列/マップを作って差分や漏れを防ぐ。
 // 固定のCNAMEにしてしまうと、証明書の再作成やSAN変更で検証に失敗する。
 locals {
-  acm_domain_names = toset(concat(
-    [aws_acm_certificate.runmates.domain_name],
-    tolist(aws_acm_certificate.runmates.subject_alternative_names)
-  ))
+  // resource_record_name が同じ検証CNAMEをまとめる（wildcardとapexが同一になることがある）
+  acm_validation_records_grouped = {
+    for option in aws_acm_certificate.runmates.domain_validation_options :
+    option.resource_record_name => {
+      name   = option.resource_record_name
+      record = option.resource_record_value
+      type   = option.resource_record_type
+    }...
+  }
 
-  // wildcard は apex と同一の検証CNAMEになることが多いため重複を避ける
-  acm_validation_domains = toset([
-    for name in local.acm_domain_names :
-    name if name != "*.${aws_acm_certificate.runmates.domain_name}"
-  ])
+  acm_validation_records = {
+    for name, records in local.acm_validation_records_grouped :
+    name => records[0]
+  }
 }
 
 // ACMの検証CNAMEは再発行時に変わるため、domain_validation_options から動的生成する。
-// for_each は plan 時に確定する domain_name をキーにする（record_name は作成後に確定）。
-// wildcardとapexで同名CNAMEになる場合があるため、上書きを許容する。
+// for_each は plan 時に確定する resource_record_name をキーにし、重複は1件にまとめる。
 resource "aws_route53_record" "acm_validation" {
-  for_each = local.acm_validation_domains
+  for_each = local.acm_validation_records
 
   zone_id = data.aws_route53_zone.runmates.zone_id
-  // 各ドメインに対応する検証レコード名
-  name = one([
-    for option in aws_acm_certificate.runmates.domain_validation_options :
-    option.resource_record_name
-    if option.domain_name == each.key
-  ])
-  // 各ドメインに対応する検証レコード種別
-  type = one([
-    for option in aws_acm_certificate.runmates.domain_validation_options :
-    option.resource_record_type
-    if option.domain_name == each.key
-  ])
+  name    = each.value.name
+  type    = each.value.type
   ttl     = 300
-  // レコード値（通常は1つ）。重複があれば distinct で1件にまとめる。
-  records = distinct([for option in aws_acm_certificate.runmates.domain_validation_options : option.resource_record_value if option.domain_name == each.key])
-
-  allow_overwrite = true
+  records = [each.value.record]
 }
 
 resource "aws_acm_certificate_validation" "runmates" {


### PR DESCRIPTION
## 概要
Route53 と ACM の既存構成を Terraform で管理できるように定義を追加しました。ACM検証CNAMEは再発行時に変わる可能性があるため、`domain_validation_options` から動的に生成する方式に変更しています。重複するCNAMEは1件にまとめて管理します。

## 関連Issue
Fixes #211

## 変更内容
- [x] `terraform/envs/prod/route53_acm.tf` に Hosted Zone / レコード / ACM 定義を追加
- [x] ACM検証レコードを `domain_validation_options` から動的生成
- [x] `resource_record_name` をキーに重複排除（wildcard/apexの同一CNAMEに対応）
- [x] 検証完了を待つ `aws_acm_certificate_validation` を追加
- [x] ACM検証の理由・for_each/localsの説明コメントを追加

## 動作確認
- [x] ローカル環境での動作確認（terraform init -reconfigure / terraform plan / terraform apply）
- [x] テストの実行（docker compose exec rails bundle exec rspec）
- [x] Lintチェック（docker compose exec next npm run lint / docker compose exec rails bundle exec rubocop）

## スクリーンショット（UIの変更がある場合）
UI変更なし

## レビューポイント
既存のRoute53/ACM構成と定義内容が一致しているか確認をお願いします。

## その他
- eslint実行時に baseline-browser-mapping の更新警告が出ましたが、Lint自体は成功しています。
- `terraform/aws-infra-inventory.md` は .gitignore 対象のため変更をコミットしていません。