### PR TITLE
[IaC] ALB/TG/ListenerをTerraform管理

### DIFF
--- a/terraform/envs/prod/alb.tf
+++ b/terraform/envs/prod/alb.tf
@@ -1,0 +1,57 @@
+resource "aws_lb" "backend" {
+  name               = "runmates-alb-backend"
+  load_balancer_type = "application"
+  internal           = false
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = [aws_subnet.public_1a.id, aws_subnet.public_1c.id]
+
+  tags = {
+    Name = "runmates-alb-backend"
+  }
+}
+
+resource "aws_lb_target_group" "backend" {
+  name        = "runmates-alb-backend-tg"
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.runmates.id
+
+  health_check {
+    path                = "/api/v1/health_check"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name = "runmates-alb-backend-tg"
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.backend.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.backend.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate_validation.runmates.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+}

--- a/terraform/envs/prod/route53_acm.tf
+++ b/terraform/envs/prod/route53_acm.tf
@@ -18,8 +18,8 @@ resource "aws_route53_record" "backend_alias_a" {
   type    = "A"
 
   alias {
-    name                   = "dualstack.runmates-alb-backend-653256300.ap-northeast-1.elb.amazonaws.com."
-    zone_id                = "Z14GRHDCWA56QT"
+    name                   = "dualstack.${aws_lb.backend.dns_name}"
+    zone_id                = aws_lb.backend.zone_id
     evaluate_target_health = true
   }
 }


### PR DESCRIPTION
## 概要
ALB / Target Group / Listener をTerraformで管理できるようにしました。

## 関連Issue
Fixes #212

## 変更内容
- [x] ALB/TG/ListenerのTerraform定義を追加
- [x] backendのRoute53エイリアスをALBリソース参照に変更
- [x] 既存ALB構成に合わせて設定値を調整

## 動作確認
- [ ] ローカル環境での動作確認
- [x] テストの実行（rspec）
- [x] Lintチェック（eslint, rubocop）

## スクリーンショット（UIの変更がある場合）
N/A

## レビューポイント
Terraform plan の差分内容（タグ付与やListenerのforward定義）をご確認ください。

## その他
なし