### PR TITLE
RDS関連リソースをTerraformで定義し既存リソースをimport

### DIFF
--- a/terraform/envs/prod/outputs.tf
+++ b/terraform/envs/prod/outputs.tf
@@ -17,3 +17,9 @@ output "ecs_service_name" {
   description = "ECS service name."
   value       = aws_ecs_service.backend.name
 }
+
+# ECSタスク定義のDATABASE_URL等で接続先を参照する際に使用
+output "rds_endpoint" {
+  description = "RDS endpoint address."
+  value       = aws_db_instance.main.endpoint
+}

--- a/terraform/envs/prod/rds.tf
+++ b/terraform/envs/prod/rds.tf
@@ -1,0 +1,63 @@
+################################################################################
+# DB Subnet Group
+# RDSを配置するプライベートサブネット（1a, 1c）をグループ化。
+# network.tf で定義済みのサブネットを参照。
+################################################################################
+resource "aws_db_subnet_group" "main" {
+  name        = "runmates-rds-subnet-group"
+  description = "runmates-rds-subnet-group" # 既存リソースの実態に合わせて明示指定（省略すると "Managed by Terraform" になり差分が出る）
+  subnet_ids  = [aws_subnet.private_1a.id, aws_subnet.private_1c.id]
+}
+
+################################################################################
+# RDS Instance
+# 既存のAWSコンソールで作成済みRDSを terraform import で取り込んだもの。
+# パスワードはTerraformで管理せず、既存の値をそのまま維持する設計。
+################################################################################
+resource "aws_db_instance" "main" {
+  identifier     = "runmates-db"
+  engine         = "mysql"
+  engine_version = "8.0.42"
+  instance_class = "db.t4g.micro" # Graviton2ベースの最小インスタンス
+
+  # ストレージ: 初期20GB、オートスケーリングで最大1000GBまで自動拡張
+  allocated_storage     = 20
+  max_allocated_storage = 1000
+  storage_type          = "gp2"
+  storage_encrypted     = true
+  kms_key_id            = "arn:aws:kms:ap-northeast-1:905418297788:key/9f29d714-0cc8-4b1b-b665-eeb6bbe5eea2"
+
+  # 認証: パスワードはTerraformに書かず、既存値を維持（lifecycle.ignore_changesと組み合わせ）
+  username                    = "admin"
+  manage_master_user_password = false
+
+  # ネットワーク: プライベートサブネットに配置し、ECSからの3306のみ許可（SGはnetwork.tfで定義済み）
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  publicly_accessible    = false
+  multi_az               = false
+  availability_zone      = "ap-northeast-1a"
+
+  # AWSデフォルトのパラメータ/オプショングループを使用（カスタム定義不要）
+  parameter_group_name = "default.mysql8.0"
+  option_group_name    = "default:mysql-8-0"
+
+  # バックアップ・メンテナンス（時刻はUTC。JST深夜帯に設定済み）
+  backup_retention_period    = 1
+  backup_window              = "18:57-19:27"         # JST 03:57-04:27
+  maintenance_window         = "tue:18:17-tue:18:47" # JST 火曜 03:17-03:47
+  auto_minor_version_upgrade = true
+
+  # 保護・スナップショット
+  deletion_protection   = false
+  skip_final_snapshot   = true # terraform destroy時に最終スナップショットを要求しない
+  copy_tags_to_snapshot = true
+
+  ca_cert_identifier = "rds-ca-rsa2048-g1"
+
+  # password: Terraformにパスワードを持たせないため変更検知を無視
+  # engine_version: auto_minor_version_upgradeによる自動更新との競合を防止
+  lifecycle {
+    ignore_changes = [password, engine_version]
+  }
+}


### PR DESCRIPTION
## 概要
既存のAWSコンソールで手動作成されたRDS（MySQL）をTerraform管理に取り込む。
DB Subnet GroupとRDSインスタンスを定義し、`terraform import`で既存リソースを取り込み済み。

Fixes #215

## 変更内容
- [x] `terraform/envs/prod/rds.tf` を新規作成（DB Subnet Group + RDS Instance定義）
- [x] `terraform/envs/prod/outputs.tf` に `rds_endpoint` outputを追加

## 追加リソース

| リソース | 名前 | 説明 |
|---------|------|------|
| `aws_db_subnet_group.main` | `runmates-rds-subnet-group` | RDS配置用プライベートサブネットグループ |
| `aws_db_instance.main` | `runmates-db` | MySQL 8.0.42 / db.t4g.micro / 20GB gp2 |

## 設計ポイント
- **パスワード管理**: `lifecycle { ignore_changes = [password] }` でTerraformにパスワードを持たせない
- **バージョン管理**: `auto_minor_version_upgrade = true` との競合を避けるため `engine_version` も `ignore_changes` に含める
- **Parameter Group**: AWSデフォルト（`default.mysql8.0`）を使用しカスタム定義は不要
- **既存リソース参照**: `network.tf` の `aws_subnet.private_1a/1c` と `aws_security_group.rds` を参照

## 動作確認
- [x] `terraform fmt -check` — OK
- [x] `terraform validate` — OK
- [x] `terraform import aws_db_subnet_group.main` — 成功
- [x] `terraform import aws_db_instance.main` — 成功
- [x] `terraform plan` — **No changes**（既存インフラと完全一致）
- [x] rspec — 200 examples, 0 failures
- [x] rubocop — no offenses
- [x] eslint — All passed

## レビューポイント
- `rds.tf` の `lifecycle.ignore_changes` の設定が適切か
- `skip_final_snapshot = true` の設定（import時にTerraformが要求するため設定。既存動作に影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)