### PR TITLE
ECR関連リソースをTerraformで定義し既存リポジトリをimport

### DIFF
--- a/terraform/envs/prod/ecr.tf
+++ b/terraform/envs/prod/ecr.tf
@@ -1,0 +1,79 @@
+################################################################################
+# ECR – コンテナイメージリポジトリ
+################################################################################
+
+# -----------------------------------------------------------------------------
+# Railsアプリケーションイメージ
+# -----------------------------------------------------------------------------
+resource "aws_ecr_repository" "rails" {
+  name                 = "runmates-rails"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "rails" {
+  repository = aws_ecr_repository.rails.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "未タグイメージを30日後に自動削除"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 30
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Nginxリバースプロキシイメージ
+# -----------------------------------------------------------------------------
+resource "aws_ecr_repository" "nginx" {
+  name                 = "runmates-nginx"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "nginx" {
+  repository = aws_ecr_repository.nginx.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "未タグイメージを30日後に自動削除"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 30
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/envs/prod/outputs.tf
+++ b/terraform/envs/prod/outputs.tf
@@ -23,3 +23,13 @@ output "rds_endpoint" {
   description = "RDS endpoint address."
   value       = aws_db_instance.main.endpoint
 }
+
+output "ecr_rails_repository_url" {
+  description = "ECR repository URL for Rails application image."
+  value       = aws_ecr_repository.rails.repository_url
+}
+
+output "ecr_nginx_repository_url" {
+  description = "ECR repository URL for Nginx reverse proxy image."
+  value       = aws_ecr_repository.nginx.repository_url
+}


### PR DESCRIPTION
## 概要
AWSコンソールで手動作成されたECRリポジトリ（runmates-rails / runmates-nginx）をTerraform管理に取り込み、ライフサイクルポリシーを追加する。

## 関連Issue
Fixes #214

## 変更内容
- [x] `terraform/envs/prod/ecr.tf` 新規作成 — ECRリポジトリ2つ + ライフサイクルポリシー2つを定義
- [x] `terraform/envs/prod/outputs.tf` 編集 — ECRリポジトリURLのoutputを追加

### 定義したリソース
| リソース | 説明 |
|---------|------|
| `aws_ecr_repository.rails` | runmates-railsリポジトリ |
| `aws_ecr_repository.nginx` | runmates-nginxリポジトリ |
| `aws_ecr_lifecycle_policy.rails` | 未タグイメージ30日自動削除 |
| `aws_ecr_lifecycle_policy.nginx` | 未タグイメージ30日自動削除 |

### terraform plan結果
- リポジトリ2つ: **No changes**（import済み）
- ライフサイクルポリシー2つ: **2 to add**（新規追加のため想定通り）

## 動作確認
- [x] `terraform fmt -check` — パス
- [x] `terraform validate` — パス
- [x] `terraform import` — 2リポジトリをimport済み
- [x] `terraform plan` — 想定通りの差分（ポリシー2件追加のみ）
- [x] RSpec — 200 examples, 0 failures
- [x] Rubocop — no offenses
- [x] ESLint — all passed

## レビューポイント
- ライフサイクルポリシー（未タグイメージ30日自動削除）の設定値が妥当か
- `runmates-next` はVercelデプロイのためTerraform管理対象外としている点

## その他
- `terraform apply` はPRマージ後に実行予定（ライフサイクルポリシーの適用）