### PR TITLE
SES関連リソースをTerraformで定義し既存リソースをimport

### DIFF
--- a/terraform/envs/prod/route53_acm.tf
+++ b/terraform/envs/prod/route53_acm.tf
@@ -24,42 +24,6 @@ resource "aws_route53_record" "backend_alias_a" {
   }
 }
 
-resource "aws_route53_record" "dmarc_txt" {
-  zone_id = data.aws_route53_zone.runmates.zone_id
-  name    = "_dmarc.runmates.net"
-  type    = "TXT"
-  ttl     = 300
-
-  records = ["v=DMARC1; p=none;"]
-}
-
-resource "aws_route53_record" "ses_dkim_1" {
-  zone_id = data.aws_route53_zone.runmates.zone_id
-  name    = "clhu3amxs6v6at6avp7sm2ygja6ifr4i._domainkey.runmates.net"
-  type    = "CNAME"
-  ttl     = 1800
-
-  records = ["clhu3amxs6v6at6avp7sm2ygja6ifr4i.dkim.amazonses.com"]
-}
-
-resource "aws_route53_record" "ses_dkim_2" {
-  zone_id = data.aws_route53_zone.runmates.zone_id
-  name    = "csl3csfhgybfq4o3enw6oeins3lmvdp6._domainkey.runmates.net"
-  type    = "CNAME"
-  ttl     = 1800
-
-  records = ["csl3csfhgybfq4o3enw6oeins3lmvdp6.dkim.amazonses.com"]
-}
-
-resource "aws_route53_record" "ses_dkim_3" {
-  zone_id = data.aws_route53_zone.runmates.zone_id
-  name    = "d6p6xajgsnkpap7qiy4iuwlwwg3bzkdu._domainkey.runmates.net"
-  type    = "CNAME"
-  ttl     = 1800
-
-  records = ["d6p6xajgsnkpap7qiy4iuwlwwg3bzkdu.dkim.amazonses.com"]
-}
-
 resource "aws_acm_certificate" "runmates" {
   domain_name               = "runmates.net"
   subject_alternative_names = ["*.runmates.net"]

--- a/terraform/envs/prod/ses.tf
+++ b/terraform/envs/prod/ses.tf
@@ -1,0 +1,65 @@
+# ==============================================================================
+# SES (Simple Email Service) - ドメイン認証 & メール送信設定
+# ==============================================================================
+
+# SESドメインID: runmates.net のメール送信元ドメインを登録
+resource "aws_ses_domain_identity" "runmates" {
+  domain = "runmates.net"
+}
+
+# DKIM設定: メールの送信元ドメインを電子署名で検証
+resource "aws_ses_domain_dkim" "runmates" {
+  domain = aws_ses_domain_identity.runmates.domain
+}
+
+# DKIM検証用Route53 CNAMEレコード
+# DKIMトークンはSESドメイン登録時に固定されるため、localsで定義
+locals {
+  ses_dkim_tokens = toset([
+    "clhu3amxs6v6at6avp7sm2ygja6ifr4i",
+    "csl3csfhgybfq4o3enw6oeins3lmvdp6",
+    "d6p6xajgsnkpap7qiy4iuwlwwg3bzkdu",
+  ])
+}
+
+resource "aws_route53_record" "ses_dkim" {
+  for_each = local.ses_dkim_tokens
+
+  zone_id = data.aws_route53_zone.runmates.zone_id
+  name    = "${each.value}._domainkey.runmates.net"
+  type    = "CNAME"
+  ttl     = 1800
+
+  records = ["${each.value}.dkim.amazonses.com"]
+}
+
+# DMARCレコード: なりすましメール対策ポリシー
+resource "aws_route53_record" "dmarc_txt" {
+  zone_id = data.aws_route53_zone.runmates.zone_id
+  name    = "_dmarc.runmates.net"
+  type    = "TXT"
+  ttl     = 300
+
+  records = ["v=DMARC1; p=none;"]
+}
+
+# ECSタスクからSES経由でメール送信するためのインラインポリシー
+resource "aws_iam_role_policy" "ecs_ses_send_email" {
+  name = "ECS-SES-SendEmail-Policy"
+  role = aws_iam_role.ecs_task_execution.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Statement1"
+        Effect = "Allow"
+        Action = [
+          "ses:SendEmail",
+          "ses:SendRawEmail"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}


### PR DESCRIPTION
## 概要
SES（ドメイン認証・DKIM・メール送信ポリシー）がAWSコンソールで手動作成されており、Terraform未管理だったため、すべてTerraformで管理できるようにする。

## 関連Issue
Fixes #224

## 変更内容
- [x] `ses.tf` 新規作成 — SESドメインID、DKIM設定、DKIMレコード（for_each動的管理）、DMARCレコード、IAMインラインポリシーを定義
- [x] `route53_acm.tf` からSES関連レコード（DKIM×3、DMARC）を削除し `ses.tf` に移動
- [x] 既存AWSリソースを `terraform import` でstate取り込み
- [x] `terraform plan` で差分なし（No changes）を確認

### Terraform state操作
| 操作 | 対象 |
|------|------|
| `state rm` | 旧DKIMレコード×3（個別定義→for_each化のため） |
| `import` | `aws_ses_domain_identity.runmates` |
| `import` | `aws_ses_domain_dkim.runmates` |
| `import` | `aws_iam_role_policy.ecs_ses_send_email` |
| `import` | `aws_route53_record.ses_dkim["..."]` ×3 |

## 動作確認
- [x] `terraform plan` で No changes を確認
- [x] RSpec通過
- [x] Rubocop通過
- [x] ESLint通過

## レビューポイント
- DKIMトークンを `locals` で静的定義している点（`aws_ses_domain_dkim.dkim_tokens` はapply時にしか確定しないため `for_each` で直接参照できない）
- IAMインラインポリシーの `Sid = "Statement1"` はAWS側の既存設定に合わせたもの

## その他
- `jh1209aws@gmail.com` のSESメールID → 個人開発用のためTerraform管理対象外
- SES Configuration Sets → 0件のため現時点では不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)