### PR TITLE
距離入力フォームのスピナー刻みを1kmに変更し、UXを改善

### DIFF
--- a/next/src/features/running/components/forms/ClientGoalForm.tsx
+++ b/next/src/features/running/components/forms/ClientGoalForm.tsx
@@ -120,7 +120,7 @@ export default function ClientGoalForm({
                   <FormControl>
                     <Input
                       type="number"
-                      step="0.1"
+                      step="any"
                       min="1"
                       placeholder="50.0"
                       {...field}

--- a/next/src/features/running/components/forms/ClientPlanForm.tsx
+++ b/next/src/features/running/components/forms/ClientPlanForm.tsx
@@ -169,6 +169,7 @@ export default function ClientPlanForm({
 
         <Form {...form}>
           <form
+            noValidate
             onSubmit={form.handleSubmit(handleSubmit)}
             className="space-y-4"
           >
@@ -181,8 +182,8 @@ export default function ClientPlanForm({
                   <FormControl>
                     <Input
                       type="number"
-                      step="0.1"
-                      min="0.1"
+                      step="any"
+                      min="1"
                       max="999"
                       placeholder="10.0"
                       {...field}

--- a/next/src/features/running/components/forms/ClientRecordForm.tsx
+++ b/next/src/features/running/components/forms/ClientRecordForm.tsx
@@ -164,7 +164,11 @@ export default function ClientRecordForm({
         </DialogHeader>
 
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <form
+            noValidate
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="space-y-4"
+          >
             {/* 日付はカレンダーで選択した値をhiddenで送る */}
             <FormField
               control={form.control}
@@ -187,8 +191,8 @@ export default function ClientRecordForm({
                   <FormControl>
                     <Input
                       type="number"
-                      step="0.1"
-                      min="0.1"
+                      step="any"
+                      min="1"
                       placeholder="5.0"
                       {...field}
                       onChange={(e) => {

--- a/next/src/features/running/components/forms/ClientYearlyGoalForm.tsx
+++ b/next/src/features/running/components/forms/ClientYearlyGoalForm.tsx
@@ -119,7 +119,7 @@ export default function ClientYearlyGoalForm({
                   <FormControl>
                     <Input
                       type="number"
-                      step="0.1"
+                      step="any"
                       min="50"
                       max="2000"
                       placeholder="500.0"


### PR DESCRIPTION
## Summary

- 全距離入力フォーム（記録・予定・月間目標・年間目標）の`step`属性を`0.1`から`any`に変更し、スピナーが1km刻みで動作するように改善
- `ClientRecordForm`と`ClientPlanForm`に`noValidate`を追加し、ブラウザのHTML5バリデーションを無効化（Zodバリデーションに一任）
- スピナー初回クリックで1kmに設定されるが、キーボード入力で0.5kmなど1km未満の値も登録可能

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `ClientRecordForm.tsx` | `step="any"`, `min="1"`, `noValidate` 追加 |
| `ClientPlanForm.tsx` | `step="any"`, `min="1"`, `noValidate` 追加 |
| `ClientGoalForm.tsx` | `step="any"` に変更 |
| `ClientYearlyGoalForm.tsx` | `step="any"` に変更 |

## Test plan

- [x] `npm run build` ビルドエラーなし
- [x] `npm run lint` リントエラーなし
- [x] `bundle exec rubocop` 違反なし
- [x] `bundle exec rspec` 200 examples, 0 failures
- [ ] スピナーで距離が1ずつ増減すること
- [ ] キーボードで小数値（0.5km等）が入力・登録できること
- [ ] 各フォーム（記録・予定・月間目標・年間目標）で動作確認

Fixes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)