### PR TITLE
設定画面の「ダッシュボードに戻る」リンク先を修正

### DIFF
--- a/next/src/app/settings/page.tsx
+++ b/next/src/app/settings/page.tsx
@@ -72,7 +72,7 @@ export default async function SettingsPage() {
 
           <div className="mt-8">
             <Link
-              href="/"
+              href="/dashboard"
               className="inline-flex items-center font-medium text-green-600 hover:text-green-700"
             >
               ← ダッシュボードに戻る


### PR DESCRIPTION
## Summary

- 設定画面（`/settings`）の「ダッシュボードに戻る」リンクの `href` を `"/"` から `"/dashboard"` に修正

## 背景

「ダッシュボードに戻る」ボタンのリンク先がLP画面（`/`）になっており、ダッシュボード（`/dashboard`）に遷移しなかった。

## 変更ファイル

- `next/src/app/settings/page.tsx` — `href="/"` → `href="/dashboard"`

Fixes #240

## Test plan

- [x] `docker-compose exec next npm run lint` — 成功
- [x] `docker-compose exec rails bundle exec rubocop` — 111ファイル、違反なし
- [x] `docker-compose exec rails bundle exec rspec` — 200件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)