### PR TITLE
今月の走行距離カードに到達予定距離を表示

### DIFF
--- a/next/src/app/components/DemoDashboard.tsx
+++ b/next/src/app/components/DemoDashboard.tsx
@@ -119,6 +119,7 @@ export default function DemoDashboard() {
       <StatisticsCards
         thisYearDistance={thisYearDistance}
         thisMonthDistance={thisMonthDistance}
+        thisMonthPlannedDistance={0}
         monthlyGoalProgress={monthlyGoalProgress}
         monthlyGoal={currentMonthGoal}
         yearlyGoal={yearlyGoal}

--- a/next/src/features/running/components/dashboard/DashboardStatistics.tsx
+++ b/next/src/features/running/components/dashboard/DashboardStatistics.tsx
@@ -12,6 +12,7 @@ import CelebrationModal from './CelebrationModal';
 export default function DashboardStatistics({
   thisYearDistance,
   thisMonthDistance,
+  thisMonthPlannedDistance,
   monthlyGoalProgress,
   monthlyGoal,
   yearlyGoal,
@@ -36,6 +37,7 @@ export default function DashboardStatistics({
       <StatisticsCards
         thisYearDistance={thisYearDistance}
         thisMonthDistance={thisMonthDistance}
+        thisMonthPlannedDistance={thisMonthPlannedDistance}
         monthlyGoalProgress={monthlyGoalProgress}
         monthlyGoal={monthlyGoal}
         yearlyGoal={yearlyGoal}

--- a/next/src/features/running/components/dashboard/ServerRunningDashboard.tsx
+++ b/next/src/features/running/components/dashboard/ServerRunningDashboard.tsx
@@ -54,6 +54,9 @@ async function DashboardData() {
 
     const thisYearDistance = Number(statistics?.this_year_distance || 0);
     const thisMonthDistance = Number(statistics?.this_month_distance || 0);
+    const thisMonthPlannedDistance = Number(
+      statistics?.this_month_planned_distance || 0,
+    );
 
     // 今月の目標を取得(設定してなければnull)
     const monthlyGoalValue = monthlyGoal?.distance_goal
@@ -95,6 +98,7 @@ async function DashboardData() {
         <DashboardStatistics
           thisYearDistance={thisYearDistance}
           thisMonthDistance={thisMonthDistance}
+          thisMonthPlannedDistance={thisMonthPlannedDistance}
           monthlyGoalProgress={monthlyGoalProgress}
           monthlyGoal={monthlyGoalValue}
           yearlyGoal={yearlyGoalValue}

--- a/next/src/features/running/components/statistics/StatisticsCards.tsx
+++ b/next/src/features/running/components/statistics/StatisticsCards.tsx
@@ -8,6 +8,7 @@ type StatisticsCardsProps = Omit<
 export default function StatisticsCards({
   thisYearDistance,
   thisMonthDistance,
+  thisMonthPlannedDistance,
   monthlyGoalProgress,
   monthlyGoal,
   yearlyGoal,
@@ -98,6 +99,12 @@ export default function StatisticsCards({
             <p className="text-4xl font-black text-slate-900">
               {thisMonthDistance.toFixed(1)} km
             </p>
+            {thisMonthPlannedDistance > 0 && (
+              <p className="text-sm font-semibold text-cyan-700">
+                到達予定:{' '}
+                {(thisMonthDistance + thisMonthPlannedDistance).toFixed(1)} km
+              </p>
+            )}
             <p className="text-sm font-semibold text-cyan-800">
               練習日: {monthlyRunDays}日
             </p>

--- a/next/src/features/running/types/index.ts
+++ b/next/src/features/running/types/index.ts
@@ -57,6 +57,7 @@ export interface YearlyGoal {
 export interface RunningStatistics {
   this_year_distance: number;
   this_month_distance: number;
+  this_month_planned_distance: number;
   total_records: number;
   recent_records: RunRecord[];
 }
@@ -71,6 +72,7 @@ export interface RunningStatistics {
 export interface DashboardStatisticsProps {
   thisYearDistance: number;
   thisMonthDistance: number;
+  thisMonthPlannedDistance: number;
   monthlyGoalProgress: number;
   monthlyGoal: number | null;
   yearlyGoal: number | null;

--- a/rails/app/controllers/api/v1/running_statistics_controller.rb
+++ b/rails/app/controllers/api/v1/running_statistics_controller.rb
@@ -9,6 +9,11 @@ class Api::V1::RunningStatisticsController < Api::V1::BaseController
     stats = {
       this_year_distance: current_user.running_records.for_year(current_year).sum(:distance),
       this_month_distance: current_user.running_records.for_month(current_year, current_month).sum(:distance),
+      this_month_planned_distance: current_user.running_plans.
+                                     status_planned.
+                                     for_month(current_year, current_month).
+                                     where(date: Date.current..).
+                                     sum(:planned_distance),
       total_records: current_user.running_records.count,
       recent_records: ActiveModelSerializers::SerializableResource.new(
         current_user.running_records.recent.limit(5),

--- a/rails/spec/requests/api/v1/running_statistics_spec.rb
+++ b/rails/spec/requests/api/v1/running_statistics_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::RunningStatistics" do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:user) { create(:user) }
   let(:headers) { user.create_new_auth_token }
 
@@ -62,6 +64,141 @@ RSpec.describe "Api::V1::RunningStatistics" do
           expect(json_response["this_month_distance"]).to eq("0.0")
           expect(json_response["total_records"]).to eq(0)
           expect(json_response["recent_records"]).to eq([])
+        end
+      end
+    end
+
+    context "this_month_planned_distance" do
+      # 月初・月末や境界の影響を避けるため、月の中旬に固定する
+      let(:fixed_today) { Date.new(2026, 5, 15) }
+      let(:other_user) { create(:user) }
+
+      before { travel_to(fixed_today) }
+
+      context "今月かつ今日以降の planned 予定がある場合" do
+        before do
+          # 今日以降の今月の planned 予定（加算される）
+          create(:running_plan, user: user, date: fixed_today, planned_distance: 5.0, status: "planned")
+          create(:running_plan, user: user, date: fixed_today + 1.day, planned_distance: 3.0, status: "planned")
+        end
+
+        it "今月かつ今日以降の planned 予定の planned_distance 合計を返すこと" do
+          get "/api/v1/running_statistics", headers: headers, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["this_month_planned_distance"]).to eq("8.0")
+        end
+      end
+
+      context "ステータスが partial / completed の場合" do
+        before do
+          create(:running_plan, user: user, date: fixed_today, planned_distance: 10.0, status: "partial")
+          create(:running_plan, user: user, date: fixed_today, planned_distance: 7.0, status: "completed")
+        end
+
+        it "partial / completed の予定は加算されないこと" do
+          get "/api/v1/running_statistics", headers: headers, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["this_month_planned_distance"]).to eq("0.0")
+        end
+      end
+
+      context "先月・翌月の planned 予定がある場合" do
+        before do
+          create(:running_plan, user: user, date: fixed_today.prev_month, planned_distance: 6.0, status: "planned")
+          create(:running_plan, user: user, date: fixed_today.next_month.beginning_of_month,
+                                planned_distance: 4.0, status: "planned")
+        end
+
+        it "今月外の予定は加算されないこと" do
+          get "/api/v1/running_statistics", headers: headers, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["this_month_planned_distance"]).to eq("0.0")
+        end
+      end
+
+      context "今月の planned 予定でも日付が過去の場合" do
+        before do
+          create(:running_plan, user: user, date: fixed_today - 1.day, planned_distance: 6.0, status: "planned")
+        end
+
+        it "過去日付の planned は加算されないこと" do
+          get "/api/v1/running_statistics", headers: headers, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["this_month_planned_distance"]).to eq("0.0")
+        end
+      end
+
+      context "今月の planned 予定で日付が今日の場合" do
+        before do
+          create(:running_plan, user: user, date: fixed_today, planned_distance: 4.5, status: "planned")
+        end
+
+        it "今日の planned は加算されること" do
+          get "/api/v1/running_statistics", headers: headers, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["this_month_planned_distance"]).to eq("4.5")
+        end
+      end
+
+      context "今月の planned 予定で日付が未来（同月内）の場合" do
+        before do
+          create(:running_plan, user: user, date: fixed_today + 5.days, planned_distance: 7.5, status: "planned")
+        end
+
+        it "未来日付の planned は加算されること" do
+          get "/api/v1/running_statistics", headers: headers, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["this_month_planned_distance"]).to eq("7.5")
+        end
+      end
+
+      context "他ユーザーの planned 予定がある場合" do
+        before do
+          create(:running_plan, user: other_user, date: fixed_today, planned_distance: 9.9, status: "planned")
+        end
+
+        it "他ユーザーの予定は加算されないこと" do
+          get "/api/v1/running_statistics", headers: headers, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["this_month_planned_distance"]).to eq("0.0")
+        end
+      end
+
+      context "対象となる予定が0件の場合" do
+        it "0.0 を返すこと" do
+          get "/api/v1/running_statistics", headers: headers, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to have_key("this_month_planned_distance")
+          expect(response.parsed_body["this_month_planned_distance"]).to eq("0.0")
+        end
+      end
+
+      context "既存統計値との非破壊" do
+        before do
+          # 今月の実績
+          create(:running_record, user: user, date: fixed_today, distance: 5.0)
+          # 今月の planned（今日以降）
+          create(:running_plan, user: user, date: fixed_today + 2.days, planned_distance: 3.0, status: "planned")
+        end
+
+        it "既存の this_year_distance / this_month_distance / total_records / recent_records は変化しないこと" do
+          get "/api/v1/running_statistics", headers: headers, as: :json
+
+          json_response = response.parsed_body
+          expect(json_response["this_year_distance"]).to eq("5.0")
+          expect(json_response["this_month_distance"]).to eq("5.0")
+          expect(json_response["total_records"]).to eq(1)
+          expect(json_response["recent_records"]).to be_an(Array)
+          expect(json_response["recent_records"].size).to eq(1)
+          expect(json_response["this_month_planned_distance"]).to eq("3.0")
         end
       end
     end

--- a/rails/swagger/v1/swagger.yaml
+++ b/rails/swagger/v1/swagger.yaml
@@ -635,6 +635,10 @@ paths:
                         type: number
                         format: float
                         description: 最長走行距離（km）
+                      this_month_planned_distance:
+                        type: number
+                        format: float
+                        description: 今月かつ今日以降の未完了予定（status=planned）の planned_distance 合計（km）
                       current_month:
                         type: object
                         properties:


### PR DESCRIPTION
## 概要
今月の走行距離カードに、今日以降の未完了予定(status: planned)を加算した「到達予定」距離を併記する。ユーザーがランニング予定を登録した時点で、このまま予定どおり走れば今月どこまで到達するかを一目で把握できるようにする。

## 関連Issue
Fixes #287

## 変更内容
- [x] バックエンド: `running_statistics_controller#show` のレスポンスに `this_month_planned_distance` を追加（今月かつ `date >= Date.current` の `status: planned` の `planned_distance` 合計）
- [x] フロントエンド: `StatisticsCards` の「今月の距離」カードに、`thisMonthPlannedDistance > 0` のときだけ実績値の直下に「到達予定: XX.X km」を表示
- [x] Swagger: `this_month_planned_distance` プロパティを追加
- [x] RSpec: 過去/今日/未来の境界、ステータス絞り込み、ユーザー絞り込み、0件、既存値の非破壊などのシナリオを追加（9件）

## 仕様の要点
- 加算対象は **今月かつ今日以降（今日を含む）** の `status: planned` 予定のみ
- 過去日付の planned は「未消化分」と見なし加算しない（到達不可能な距離が表示されないように）
- 未完了予定が 0 件のときはカッコ/到達予定行を表示しない（現状の見た目を維持）

## 動作確認
- [x] ローカル環境での動作確認（Playwright MCPでデスクトップ・モバイル 375x667 ともに確認済み。実績のみ→未来予定追加→到達予定表示→過去予定追加でも到達予定が変わらないことを確認）
- [x] RSpec: 196 examples, 0 failures
- [x] Rubocop: 113 files inspected, no offenses
- [x] Next.js lint: pass

## スクリーンショット
**実績のみ（予定なし）:**
```
今月の距離
21.9 km
練習日: 3日
```

**未来予定あり（5/15 に 8.0km の planned を追加）:**
```
今月の距離
21.9 km
到達予定: 29.9 km
練習日: 3日
```

## レビューポイント
- バックエンドのクエリ `status_planned.for_month(...).where(date: Date.current..).sum(:planned_distance)` の組み立て方（既存スコープを再利用しつつ、`where(date: Date.current..)` で「今日以降」に絞り込み）
- `StatisticsCards` の挿入位置（実績値と「練習日」の間に `text-sm font-semibold text-cyan-700` の控えめなラベル付き行）

## その他
- Swagger は本Issueの対応プロパティ追加のみ実施。既存項目との不整合解消はスコープ外（別Issueで扱う想定）。
- DemoDashboard はランディング用のデモ表示のため `thisMonthPlannedDistance={0}` 固定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)