### PR TITLE
fix: 本番のSolidQueueワーカーをPumaプラグインで起動しメール送信を復旧 (#296)

### DIFF
--- a/rails/config/puma.rb
+++ b/rails/config/puma.rb
@@ -3,5 +3,9 @@ threads threads_count, threads_count
 environment ENV.fetch("RAILS_ENV") { "development" }
 plugin :tmp_restart
 
+# 本番のみ Puma プロセス内で SolidQueue ワーカーを同居起動する。
+# development は docker-compose の worker コンテナがジョブを処理するため有効化しない（二重起動防止）。
+plugin :solid_queue if ENV.fetch("RAILS_ENV") { "development" } == "production"
+
 app_root = File.expand_path("..", __dir__)
 bind "unix://#{app_root}/tmp/sockets/puma.sock"

--- a/rails/entrypoint.prod.sh
+++ b/rails/entrypoint.prod.sh
@@ -27,13 +27,5 @@ if bundle exec rails runner "puts User.count" RAILS_ENV=production | grep -q "0"
   bundle exec rails db:seed RAILS_ENV=production
 fi
 
-echo "Starting SolidQueue worker in background..."
-bundle exec rake solid_queue:start &
-WORKER_PID=$!
-echo "SolidQueue worker started with PID: $WORKER_PID"
-
-# ワーカーが起動するまで少し待つ
-sleep 3
-
 echo "Starting puma server..."
 bundle exec puma -C config/puma.rb


### PR DESCRIPTION
## 概要

本番でメールが一切送信されない問題（パスワードリセット・本人確認など全メール）を修正します。SES は正常で、根本原因は **SolidQueue ワーカーが本番で安定動作していなかったこと**でした。起動方式を Puma プラグインに一本化し、ワーカー停止を自己検知・自己復旧できる構成にします。

## 関連Issue

Fixes #296

## 原因（Issue 本文との差分あり）

Issue は「本番にワーカーが一切存在しない」としていましたが、調査の結果 `entrypoint.prod.sh` に `rake solid_queue:start &`（fire-and-forget 起動）が**既に存在**していました（`317aa6e` で追加）。実態は **「`&` 起動が誰にも監視されず、一度落ちると永久に復帰しない」構造的脆弱性**です。

- ワーカーが落ちても shell は気づかず、Puma（Web）は healthy のまま残る
- ECS から見てもコンテナは正常 → 再起動されない
- 結果、API は `200 OK`・`Enqueued` は出るが `Performing` が出ず、メールだけ恒久停止（`SentLast24Hours: 0.0`）

## 変更内容

- [x] `config/puma.rb` に本番限定で `plugin :solid_queue` を追加（Puma が fork でワーカーを起動し双方向監視。片方が落ちたら道連れに停止 → ECS ヘルスチェック失敗 → タスク再起動で自己復旧）
- [x] `entrypoint.prod.sh` の `rake solid_queue:start &` ブロックを削除し、起動経路を Puma プラグインに一本化（二重起動防止）
- [x] development は docker-compose の `worker` コンテナが処理するため `RAILS_ENV` ガードでプラグインを無効化（二重起動防止）

## 動作確認

- [x] ローカル環境での動作確認（development で `rake solid_queue:start` が正常起動することを確認）
- [x] テストの実行（`rspec spec/jobs spec/mailers` 18 examples 0 failures / pre-commit hook 全体 196 examples 0 failures）
- [x] Lintチェック（Rubocop no offenses / npm lint OK / tsc OK）

## レビューポイント

- `plugin :solid_queue` は **本番のみ**有効化しています。development・test で二重起動しないことが意図通りか確認ください。
- 本 PR では方針A（Puma プラグイン同居）を採用しています。将来ジョブ負荷が増えた場合は ECS に専用 worker サービスを分離する方針B も検討余地があります（今回はスコープ外）。

## デプロイ後の確認（本番でのみ検証可能・残タスク）

- [ ] 本番起動ログに Puma の SolidQueue プラグイン起動が出て、旧 `SolidQueue worker started with PID:` が**出ない**こと
- [ ] パスワードリセット等で `solid_queue_jobs` が処理され、SES `SentLast24Hours` が増加し、実際にメールが届くこと

## その他

- SolidQueue プラグインの仕組み: https://github.com/rails/solid_queue#puma-plugin
- 滞留している既存ジョブはワーカー起動後に順次処理される見込みです。古いトークンは期限切れの可能性があり、滞留ジョブの実行/破棄はデプロイ時に判断してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)