### PR TITLE
fix: rack_attack_specの時間窓境界跨ぎによるflakyを解消

### DIFF
--- a/rails/spec/rails_helper.rb
+++ b/rails/spec/rails_helper.rb
@@ -72,6 +72,9 @@ RSpec.configure do |config|
 
   # FactoryBotの宣言を省略
   config.include FactoryBot::Syntax::Methods
+
+  # Rack::Attackテストでのみ時刻固定ヘルパー（freeze_time）を利用可能にする（復元はteardownで自動実行）
+  config.include ActiveSupport::Testing::TimeHelpers, :rack_attack
 end
 
 # Shoulda Matchersの設定

--- a/rails/spec/support/rack_attack.rb
+++ b/rails/spec/support/rack_attack.rb
@@ -7,6 +7,8 @@ RSpec.configure do |config|
   config.before(:each, :rack_attack) do
     Rack::Attack.enabled = true
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    # 固定時間窓（fixed window）の境界跨ぎによるflakyを防ぐため時刻を固定する
+    freeze_time
   end
 
   config.after(:each, :rack_attack) do


### PR DESCRIPTION
## 概要
`spec/requests/rack_attack_spec.rb` のレート制限テストが、CI で稀に 429 ではなく 401 を返して失敗する（flaky）問題を解消します。`:rack_attack` タグ付きテストの実行中だけ時刻を固定し、全 POST を同一の固定時間窓に閉じ込めることで、確実に 429 を検証できるようにします。

## 関連Issue
Fixes #299

## 原因
Rack::Attack の throttle は固定時間窓（fixed window, `period: 60`）でカウントするため、「N 回 POST → N+1 回目で 429」を検証するテストが 60 秒境界をまたぐと、N+1 回目が新しい窓のカウント 1 扱いになり制限が発動せず、通常の認証失敗 401 が返ってしまう。CI は実行が遅くタイミングがずれやすいため flaky になっていた。

## 変更内容
- [x] `spec/support/rack_attack.rb`: `before(:each, :rack_attack)` に `freeze_time` を追加し、全 POST を同一時間窓に固定
- [x] `spec/rails_helper.rb`: `ActiveSupport::Testing::TimeHelpers` を `:rack_attack` タグ限定で include（他テストへ漏れない）
- [x] 時刻復元は Rails 8.1 の TimeHelpers が teardown で `travel_back` を自動実行するため、明示的な `travel_back` は不要（追加しない）

プロダクションコード（initializer 等）への変更はありません。

## 動作確認
- [x] ローカル環境での動作確認（Docker コンテナ内）
- [x] テストの実行: `rack_attack_spec` を複数回連続実行し、すべて 5 examples / 0 failures（flaky 解消を確認）
- [x] Lintチェック: Rubocop 違反なし（disable コメント不要）
- [x] 全体テスト: 196 examples, 0 failures（pre-commit hook）

## レビューポイント
- `freeze_time` の include を `:rack_attack` タグ限定にしており、他テストの時刻には影響しません。
- `travel_back` を手書きしていないのは Rails 8.1 の自動復元に委ねているためです（タグ外テストで実時刻が進むことを検証済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)