### PR TITLE
refactor: フロントエンドURL管理をcredentialsに統一しconfig gem(Settings)を削除

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -26,8 +26,8 @@ gem "tzinfo-data", platforms: %i[windows jruby]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
-# 環境毎の設定管理を行う
-gem "config"
+# Ruby 4.0でデフォルトgemから外れたため明示（aws-recordが実行時に依存）
+gem "ostruct"
 
 # ユーザー認証を提供する
 gem "devise"

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -173,16 +173,12 @@ GEM
       logger (~> 1.5)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
-    config (5.5.2)
-      deep_merge (~> 1.2, >= 1.2.1)
-      ostruct
     connection_pool (3.0.2)
     crass (1.0.6)
     date (3.5.1)
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    deep_merge (1.2.2)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -282,7 +278,7 @@ GEM
     nokogiri (1.19.0-x86_64-linux-musl)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    ostruct (0.6.2)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -486,7 +482,6 @@ DEPENDENCIES
   brakeman
   bullet (= 8.1.0)
   bundler-audit
-  config
   debug
   devise
   devise-i18n
@@ -496,6 +491,7 @@ DEPENDENCIES
   letter_opener_web
   mysql2 (~> 0.5)
   net-imap (>= 0.5.10)
+  ostruct
   pry-byebug
   pry-rails
   puma (>= 5.0)

--- a/rails/config/initializers/cors.rb
+++ b/rails/config/initializers/cors.rb
@@ -1,6 +1,9 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins Settings.front_domain
+    origins(
+      Rails.application.credentials.dig(Rails.env.to_sym, :frontend_url) ||
+        "http://localhost:8000",
+    )
 
     resource "*",
              headers: :any,

--- a/rails/config/settings/development.yml
+++ b/rails/config/settings/development.yml
@@ -1,1 +1,0 @@
-front_domain: "http://localhost:8000"

--- a/rails/config/settings/production.yml
+++ b/rails/config/settings/production.yml
@@ -1,1 +1,0 @@
-front_domain: "https://runmates.net"

--- a/rails/config/settings/test.yml
+++ b/rails/config/settings/test.yml
@@ -1,1 +1,0 @@
-front_domain: "http://localhost:8000"


### PR DESCRIPTION
## 概要
二重管理されていたフロントエンドURLを `Rails.application.credentials` に一本化し、`config` gem（Settings）への依存を削除する内部リファクタリングです。`config` gem は `cors.rb` の1箇所のためだけに導入されていたため削除します。

## 関連Issue
Fixes #277

## 変更内容
- [x] `cors.rb` の `Settings.front_domain` を `Rails.application.credentials.dig(Rails.env.to_sym, :frontend_url)` に置換（`user_mailer.rb` と同一パターンに統一）
- [x] `config/settings/{development,test,production}.yml` を削除
- [x] `Gemfile` から `gem "config"` を削除
- [x] `config` 削除で bundle から消える `ostruct` を明示追加（後述）

## 動作確認
- [x] ローカル環境での動作確認（boot成功・`Settings` 未定義エラーなし）
- [x] テストの実行（196 examples, 0 failures）
- [x] Lintチェック（Rubocop no offenses）

## レビューポイント
### `ostruct` gem の明示追加について
`config` gem 削除に伴い必要になった対応です。
- `config (5.5.2)` が依存ツリーから `ostruct` を引き込んでいたため、削除すると bundle から `ostruct` が消える
- `aws-sdk-rails` → `aws-record` が**起動時の require チェーン**で `ostruct` を使用しており、Ruby 4.0 で `ostruct` がデフォルトgemから外れた影響で boot が `LoadError` で失敗する回帰が発生
- これを補うため `gem "ostruct"` を明示追加（Gemfileにコメントで理由を明記）

### 名前統一（Issue対応案2）は実施せず
`user_mailer.rb` は既に `frontend_url` を参照済みのため、`cors.rb` 側を合わせた時点で名前統一は完了。mailer は変更していません（不要な差分を回避）。

## その他
- 各環境の credentials に `frontend_url` 設定済みを実機確認（dev/test: `http://localhost:8000` / prod: `https://runmates.net`）。**本番デプロイで credentials 編集・master.key 変更は不要**です。
- 別途検討事項（本PR対象外）: `credentials.yml.enc` に `database_url` が含まれている点はレビューで確認済み。必要なら別Issueで扱います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)