### PR TITLE
fix: 本番ECSタスクのメモリを512MB→1024MBに増額しOOMループを解消

### DIFF
--- a/rails/task-definition.json
+++ b/rails/task-definition.json
@@ -98,7 +98,7 @@
       "FARGATE"
   ],
   "cpu": "256",
-  "memory": "512",
+  "memory": "1024",
   "runtimePlatform": {
       "cpuArchitecture": "X86_64",
       "operatingSystemFamily": "LINUX"

--- a/terraform/envs/prod/ecs.tf
+++ b/terraform/envs/prod/ecs.tf
@@ -89,14 +89,14 @@ resource "aws_ecs_cluster" "main" {
 #
 # cpu/memoryの単位:
 #   cpu = "256"  → 0.25 vCPU
-#   memory = "512" → 512 MB
+#   memory = "1024" → 1024 MB
 # -----------------------------------------------------------------------------
 resource "aws_ecs_task_definition" "backend" {
   family                   = "runmates-task-definition-backend"
   network_mode             = "awsvpc" # Fargate必須。各タスクに固有のENI（ネットワークIF）が割り当てられる
   requires_compatibilities = ["FARGATE"]
   cpu                      = "256"
-  memory                   = "512"
+  memory                   = "1024"
   execution_role_arn       = aws_iam_role.ecs_task_execution.arn # ECRからのイメージpull、CloudWatch Logsへの書き込みに使用
   task_role_arn            = aws_iam_role.ecs_task_execution.arn # コンテナ内のアプリがAWSサービスを呼ぶ際に使用
 


### PR DESCRIPTION
## 概要
本番 `rails` コンテナがメモリ不足による **OOM Kill（exitCode 137）** で約30分おきに強制終了→再起動を繰り返しており、再起動中の数十秒〜数分が **ログイン不能** の時間帯になっていた。ECSタスクのメモリを **512MB → 1024MB** に増額して解消する。

## 原因（AWS実データで確定）
- 停止タスクの `stoppedReason` が両件とも `OutOfMemoryError: container killed due to memory usage`
- サービスイベント: `17:11` replaced 1 tasks due to unhealthy status → `17:13` steady state
- CloudWatch `MemoryUtilization`: 常時90%超で張り付き、98〜99%到達→OOM Kill→40%台に急落 を反復（典型的なノコギリ波）

### 根本原因
`fix/puma-single-mode`（commit `2b4222f`）の **Puma single mode 化 + `plugin :solid_queue`** により、1つのPumaプロセスに Webリクエスト処理 + Solid Queue（supervisor / worker(threads:3) / dispatcher / scheduler）が同居。さらにDB接続プール拡張（`RAILS_MAX_THREADS+3`）も重なり、512MBに収まらずOOM。512MBは元々ギリギリで、同居化が引き金になった。
※ コード自体は正しく、ローカルではログイン正常動作を確認済み（容量の問題）。

## 変更内容
| ファイル | 変更 | 役割 |
|---|---|---|
| `rails/task-definition.json` | `memory` 512→1024 | **本番反映に必須**（CDが読む真のソース） |
| `terraform/envs/prod/ecs.tf` | `memory` 512→1024（+コメント） | state一貫性のため同期（`ignore_changes` によりapply不要） |

- `cpu`（256 = 0.25vCPU）は変更なし。Fargate制約上 0.25vCPU で 1024MB は有効な組み合わせ。

## デプロイ
- mainマージで `.github/workflows/cd.yml` が自動実行され本番ECSが新task definitionで更新される
- **terraform apply は不要**

## マージ後の検証
- `aws ecs describe-services` で steady state と新リビジョン稼働を確認
- CloudWatch `MemoryUtilization` が90%張り付きから低下し、OOM Kill が止まることを数十分観察
- https://runmates.net でログインが安定して通ることを確認

## 補足（将来・スコープ外）
jemalloc導入 / `MALLOC_ARENA_MAX=2` / Solid Queue スレッド数調整によるメモリ効率改善も検討余地あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
